### PR TITLE
Fix conflict between unary and binary `-` operator

### DIFF
--- a/examples/counter.tla
+++ b/examples/counter.tla
@@ -66,7 +66,9 @@ Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
 \* END TRANSLATION
 
+(* If all processes are done, the counter should be equal the
+   number of processes times the number of iterations each performed *)
 CounterConverges ==
-    Termination => (counter = procs * iters)
+    (\A self \in ProcSet: pc[self] = "Done") => (counter = procs * iters)
 
-====
+======================================================================

--- a/examples/counter.tla
+++ b/examples/counter.tla
@@ -1,4 +1,4 @@
---------------------------- MODULE counter ---------------------------
+--------------------------- MODULE round_robin ---------------------------
 
 EXTENDS Integers, TLC
 
@@ -6,20 +6,17 @@ CONSTANT procs, iters
 
 (*
 
---algorithm counter {
+--algorithm round_robin {
   (** @PGo{ arg procs int }@PGo
       @PGo{ arg iters int }@PGo
    **)
-  variables counter = 0,
-            token = -1;
+  variables counter = 0;
 
   fair process (P \in 0..procs-1)
   variables i = 0;
   {
       w: while (i < iters) {
-          waitToken:  await token = -1 \/ token = self;
           incCounter: counter := counter + 1;
-                      token := (self + 1) % procs;
                       print counter;
           nextIter:   i := i + 1;
       }
@@ -27,66 +24,4 @@ CONSTANT procs, iters
 }
 *)
 
-\* BEGIN TRANSLATION
-VARIABLES counter, token, pc, i
-
-vars == << counter, token, pc, i >>
-
-ProcSet == (0..procs-1)
-
-Init == (* Global variables *)
-        /\ counter = 0
-        /\ token = -1
-        (* Process P *)
-        /\ i = [self \in 0..procs-1 |-> 0]
-        /\ pc = [self \in ProcSet |-> "w"]
-
-w(self) == /\ pc[self] = "w"
-           /\ IF i[self] < iters
-                 THEN /\ pc' = [pc EXCEPT ![self] = "waitToken"]
-                 ELSE /\ pc' = [pc EXCEPT ![self] = "Done"]
-           /\ UNCHANGED << counter, token, i >>
-
-waitToken(self) == /\ pc[self] = "waitToken"
-                   /\ token = -1 \/ token = self
-                   /\ pc' = [pc EXCEPT ![self] = "incCounter"]
-                   /\ UNCHANGED << counter, token, i >>
-
-incCounter(self) == /\ pc[self] = "incCounter"
-                    /\ counter' = counter + 1
-                    /\ token' = (self + 1) % procs
-                    /\ pc' = [pc EXCEPT ![self] = "nextIter"]
-                    /\ i' = i
-
-nextIter(self) == /\ pc[self] = "nextIter"
-                  /\ i' = [i EXCEPT ![self] = i[self] + 1]
-                  /\ pc' = [pc EXCEPT ![self] = "w"]
-                  /\ UNCHANGED << counter, token >>
-
-P(self) == w(self) \/ waitToken(self) \/ incCounter(self) \/ nextIter(self)
-
-Next == (\E self \in 0..procs-1: P(self))
-           \/ (* Disjunct to prevent deadlock on termination *)
-              ((\A self \in ProcSet: pc[self] = "Done") /\ UNCHANGED vars)
-
-Spec == /\ Init /\ [][Next]_vars
-        /\ \A self \in 0..procs-1 : WF_vars(P(self))
-
-Termination == <>(\A self \in ProcSet: pc[self] = "Done")
-
-\* END TRANSLATION
-
-
-TokenWithinBounds == 
-  token = -1 \/ token \in 0..procs-1
-
-CounterConverges ==
-    Termination => (counter = procs * iters)
-
-ProcessesGetToken ==
-    \A self \in ProcSet : <>(token = self)
-
-=============================================================================
-\* Modification History
-\* Last modified Fri Jun 08 13:09:07 PDT 2018 by rmc
-\* Created Thu May 03 23:02:12 PDT 2018 by rmc
+====

--- a/examples/counter.tla
+++ b/examples/counter.tla
@@ -20,6 +20,7 @@ CONSTANT procs, iters
           waitToken:  await token = -1 \/ token = self;
           incCounter: counter := counter + 1;
                       token := (self + 1) % procs;
+                      print counter;
           nextIter:   i := i + 1;
       }
   }

--- a/examples/round_robin.tla
+++ b/examples/round_robin.tla
@@ -1,0 +1,92 @@
+--------------------------- MODULE round_robin ---------------------------
+
+EXTENDS Integers, TLC
+
+CONSTANT procs, iters
+
+(*
+
+--algorithm round_robin {
+  (** @PGo{ arg procs int }@PGo
+      @PGo{ arg iters int }@PGo
+   **)
+  variables counter = 0,
+            token = -1;
+
+  fair process (P \in 0..procs-1)
+  variables i = 0;
+  {
+      w: while (i < iters) {
+          waitToken:  await token = -1 \/ token = self;
+          incCounter: counter := counter + 1;
+                      token := (self + 1) % procs;
+                      print counter;
+          nextIter:   i := i + 1;
+      }
+  }
+}
+*)
+
+\* BEGIN TRANSLATION
+VARIABLES counter, token, pc, i
+
+vars == << counter, token, pc, i >>
+
+ProcSet == (0..procs-1)
+
+Init == (* Global variables *)
+        /\ counter = 0
+        /\ token = -1
+        (* Process P *)
+        /\ i = [self \in 0..procs-1 |-> 0]
+        /\ pc = [self \in ProcSet |-> "w"]
+
+w(self) == /\ pc[self] = "w"
+           /\ IF i[self] < iters
+                 THEN /\ pc' = [pc EXCEPT ![self] = "waitToken"]
+                 ELSE /\ pc' = [pc EXCEPT ![self] = "Done"]
+           /\ UNCHANGED << counter, token, i >>
+
+waitToken(self) == /\ pc[self] = "waitToken"
+                   /\ token = -1 \/ token = self
+                   /\ pc' = [pc EXCEPT ![self] = "incCounter"]
+                   /\ UNCHANGED << counter, token, i >>
+
+incCounter(self) == /\ pc[self] = "incCounter"
+                    /\ counter' = counter + 1
+                    /\ token' = (self + 1) % procs
+                    /\ pc' = [pc EXCEPT ![self] = "nextIter"]
+                    /\ i' = i
+
+nextIter(self) == /\ pc[self] = "nextIter"
+                  /\ i' = [i EXCEPT ![self] = i[self] + 1]
+                  /\ pc' = [pc EXCEPT ![self] = "w"]
+                  /\ UNCHANGED << counter, token >>
+
+P(self) == w(self) \/ waitToken(self) \/ incCounter(self) \/ nextIter(self)
+
+Next == (\E self \in 0..procs-1: P(self))
+           \/ (* Disjunct to prevent deadlock on termination *)
+              ((\A self \in ProcSet: pc[self] = "Done") /\ UNCHANGED vars)
+
+Spec == /\ Init /\ [][Next]_vars
+        /\ \A self \in 0..procs-1 : WF_vars(P(self))
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION
+
+
+TokenWithinBounds == 
+  token = -1 \/ token \in 0..procs-1
+
+CounterConverges ==
+    Termination => (counter = procs * iters)
+
+ProcessesGetToken ==
+    \A self \in ProcSet : <>(token = self)
+
+=============================================================================
+\* Modification History
+\* Last modified Fri Jun 08 13:09:07 PDT 2018 by rmc
+\* Created Thu May 03 23:02:12 PDT 2018 by rmc

--- a/examples/round_robin.tla
+++ b/examples/round_robin.tla
@@ -81,7 +81,7 @@ TokenWithinBounds ==
   token = -1 \/ token \in 0..procs-1
 
 CounterConverges ==
-    Termination => (counter = procs * iters)
+    (\A self \in ProcSet: pc[self] = "Done") => (counter = procs * iters)
 
 ProcessesGetToken ==
     \A self \in ProcSet : <>(token = self)

--- a/src/pgo/parser/TLAParser.java
+++ b/src/pgo/parser/TLAParser.java
@@ -1166,9 +1166,12 @@ public final class TLAParser {
 					String opStr = op.getValue().getValue();
 					if(PREFIX_OPERATORS_LOW_PRECEDENCE.get(opStr) <= precedence && PREFIX_OPERATORS_HI_PRECEDENCE.get(opStr) >= precedence) {
 						return parseExpressionFromPrecedence(minColumn, PREFIX_OPERATORS_HI_PRECEDENCE.get(opStr) + 1).map(exp -> {
+							// operator - is the only operator that is both unary and binary, and can be defined as
+							// both simultaneously. We special-case the unary version by renaming it.
+							String value = op.getValue().getValue().equals("-") ? "-_" : op.getValue().getValue();
 							return new PGoTLAUnary(
 									seqResult.getLocation(),
-									new PGoTLASymbol(op.getValue().getLocation(), op.getValue().getValue()),
+									new PGoTLASymbol(op.getValue().getLocation(), value),
 									prefix.getValue(), exp);
 						});
 					}else {
@@ -1326,9 +1329,12 @@ public final class TLAParser {
 						part(op, parseBuiltinTokenOneOf(PREFIX_OPERATORS, minColumn)),
 						drop(parseBuiltinToken("_", minColumn))
 						).map(seqResult -> {
+							// operator - is the only operator that is both unary and binary, and can be defined as
+							// both simultaneously. We special-case the unary version by renaming it.
+							String value = op.getValue().getValue().equals("-") ? "-_" : op.getValue().getValue();
 							return PGoTLAOpDecl.Prefix(
 									seqResult.getLocation(),
-									new PGoTLAIdentifier(op.getValue().getLocation(), op.getValue().getValue()));
+									new PGoTLAIdentifier(op.getValue().getLocation(), value));
 						}),
 				sequence(
 						drop(parseBuiltinToken("_", minColumn)),
@@ -1363,7 +1369,12 @@ public final class TLAParser {
 									part(op, parseBuiltinTokenOneOf(PREFIX_OPERATORS, minColumn)),
 									part(rhs, parseIdentifier(minColumn))
 									).map(seqResult -> {
-										name.setValue(new PGoTLAIdentifier(op.getValue().getLocation(), op.getValue().getValue()));
+										// operator - is the only operator that is both unary and binary, and can
+										// be defined as both simultaneously. We special-case the unary version by
+										// renaming it.
+										String value =
+												op.getValue().getValue().equals("-") ? "-_" : op.getValue().getValue();
+										name.setValue(new PGoTLAIdentifier(op.getValue().getLocation(), value));
 										SourceLocation loc = rhs.getValue().getLocation();
 										return new LocatedList<PGoTLAOpDecl>(
 												seqResult.getLocation(),

--- a/src/pgo/trans/intermediate/TLABuiltins.java
+++ b/src/pgo/trans/intermediate/TLABuiltins.java
@@ -501,7 +501,7 @@ public class TLABuiltins {
 
 		BuiltinModule Integers = new BuiltinModule(Naturals);
 		builtinModules.put("Integers", Integers);
-		Integers.addOperator("-", new TypelessBuiltinOperator(
+		Integers.addOperator("-_", new TypelessBuiltinOperator(
 				1,
 				(origin, args, solver, generator) -> {
 					PGoType fresh = new PGoTypeUnrealizedNumber(new PGoTypeInt(Collections.singletonList(origin)), Collections.singletonList(origin));


### PR DESCRIPTION
This PR fixes the conflict between the binary and unary `-` operators by automatically renaming the unary `-` operator to `-_` during parsing. (as per convention when describing the arity of an operator in TLA+).

It turns out that this is the only operator in all of TLA+ that has this issue. All other operators have distinct names no matter their arity.

Experimenting with TLC has confirmed that any operators sharing a name is invalid. The irony here is that if you redefine `_-_` and `-_` manually, it is actually also forbidden. Only the special-case definition in `Integers` and `Reals` is allowed.

> All names should have only one meaning
-Lamport

Fixes #70 