### PR TITLE
Compiling a two phase commit protocol

### DIFF
--- a/examples/2pc.tla
+++ b/examples/2pc.tla
@@ -1,0 +1,200 @@
+----------------------------- MODULE PTwoPhase -----------------------------
+(***************************************************************************)
+(* Changes from the original TwoPhase spec, obtained at:                   *)
+(*     http://lamport.azurewebsites.net/tla/two-phase.html                 *)
+(*                                                                         *)
+(*   - Removal of CHOOSE to choose a transaction manager identifier        *)
+(*     (not supported by PGo). Use a regular constant and ASSUME they are  *)
+(*     not the same.                                                       *)
+(*   - 'tmState' and 'tmPrepared' variables move from being (unnecessarily *)
+(*     global to being local to the 'TManager''process                     *)
+(*   - Addition of the "Propose" message, sent by transaction managers to  *)
+(*     resource managers when a transaction is initiated.                  *)
+(*   - Addition of an "Abort" message from resource managers to the        *)
+(*     transaction manager, instead of having the manager spontaneously    *)
+(*     deciding to abort. That makes the spec closer to an implementation. *)
+(***************************************************************************)
+
+CONSTANT RM \* The set of resource managers
+CONSTANT TM \* The transaction manager
+
+CONSTANT data
+
+(* ASSUME TM \notin RM *)
+
+(***************************************************************************
+--algorithm TwoPhaseCommit {
+  variables rmState = [rm \in RM |-> "working"],
+            msgs = {} ;
+  macro SendMsg(m) { msgs := msgs \cup {m} }
+  macro RcvMsg(m) { await m \in msgs }
+  macro TMRcvPrepared() {
+    (***********************************************************************)
+    (* The TM receives a "Prepared" message from some resource manager.    *)
+    (***********************************************************************)
+    await tmState = "init";
+    with (rm \in RM) {
+      RcvMsg([type |-> "Prepared", rm |-> rm]);
+      tmPrepared := tmPrepared \cup {rm}
+     }
+   }
+
+  macro TMPropose() {
+    SendMsg([type |-> "Propose", data |-> data])
+  }
+
+  macro TMCommit() {
+    (***********************************************************************)
+    (* The TM commits the transaction; enabled iff the TM is in its        *)
+    (* initial state and every RM has sent a "Prepared" message.           *)
+    (***********************************************************************)
+    await /\ tmState = "init"
+          /\ tmPrepared = RM ;
+    tmState := "committed" ;
+    SendMsg([type |-> "Commit"])
+   }
+  macro TMAbort() {
+    (***********************************************************************)
+    (* The TM spontaneously aborts the transaction.                        *)
+    (***********************************************************************)
+    await tmState = "init" /\ ([type |-> "RMAborted"] \in msgs);
+    tmState := "aborted" ;
+    SendMsg([type |-> "Abort"])
+   }
+  macro RMPrepare(rm) {
+    (***********************************************************************)
+    (* Resource manager rm prepares.                                       *)
+    (***********************************************************************)
+    await rmState[rm] = "working" /\ ([type |-> "Propose", data |-> data] \in msgs);
+    rmState[rm] := "prepared" ;
+    SendMsg([type |-> "RMPrepared", rm |-> rm])
+   }
+  macro RMChooseToAbort(rm) {
+    (***********************************************************************)
+    (* Resource manager rm spontaneously decides to abort.  As noted       *)
+    (* above, rm does not send any message in our simplified spec.         *)
+    (***********************************************************************)
+    await rmState[rm] = "working" ;
+    rmState[rm] := "aborted";
+    SendMsg([type |-> "RMAborted"]);
+   }
+  macro RMRcvCommitMsg(rm) {
+    (***********************************************************************)
+    (* Resource manager rm is told by the TM to commit.                    *)
+    (***********************************************************************)
+    RcvMsg([type |-> "Commit"]) ;
+    rmState[rm] := "committed"
+   }
+  macro RMRcvAbortMsg(rm) {
+    (***********************************************************************)
+    (* Resource manager rm is told by the TM to abort.                     *)
+    (***********************************************************************)
+    RcvMsg ([type |-> "Abort"]) ;
+    rmState[rm] := "aborted"
+  }
+
+  process (TManager = TM)
+  variables tmState = "init",
+            tmPrepared = {};
+  {
+    tmstart: while (TRUE) {
+               either { TMPropose() }
+               or     { TMCommit() }
+               or     { TMAbort() }
+               or     { TMRcvPrepared() }
+             }
+   }
+  process (RManager \in RM) {
+    rmstart: while (TRUE) {
+               either { RMPrepare(self) }
+               or     { RMChooseToAbort(self) }
+               or     { RMRcvCommitMsg(self) }
+               or     { RMRcvAbortMsg(self) }
+             }
+   }
+}
+***************************************************************************)
+
+\* BEGIN TRANSLATION
+VARIABLES rmState, msgs, tmState, tmPrepared
+
+vars == << rmState, msgs, tmState, tmPrepared >>
+
+ProcSet == {TM} \cup (RM)
+
+Init == (* Global variables *)
+        /\ rmState = [rm \in RM |-> "working"]
+        /\ msgs = {}
+        (* Process TManager *)
+        /\ tmState = "init"
+        /\ tmPrepared = {}
+
+TManager == /\ \/ /\ msgs' = (msgs \cup {([type |-> "Propose", data |-> data])})
+                  /\ UNCHANGED <<tmState, tmPrepared>>
+               \/ /\ /\ tmState = "init"
+                     /\ tmPrepared = RM
+                  /\ tmState' = "committed"
+                  /\ msgs' = (msgs \cup {([type |-> "Commit"])})
+                  /\ UNCHANGED tmPrepared
+               \/ /\ tmState = "init" /\ ([type |-> "RMAborted"] \in msgs)
+                  /\ tmState' = "aborted"
+                  /\ msgs' = (msgs \cup {([type |-> "Abort"])})
+                  /\ UNCHANGED tmPrepared
+               \/ /\ tmState = "init"
+                  /\ \E rm \in RM:
+                       /\ ([type |-> "Prepared", rm |-> rm]) \in msgs
+                       /\ tmPrepared' = (tmPrepared \cup {rm})
+                  /\ UNCHANGED <<msgs, tmState>>
+            /\ UNCHANGED rmState
+
+RManager(self) == /\ \/ /\ rmState[self] = "working" /\ ([type |-> "Propose", data |-> data] \in msgs)
+                        /\ rmState' = [rmState EXCEPT ![self] = "prepared"]
+                        /\ msgs' = (msgs \cup {([type |-> "RMPrepared", rm |-> self])})
+                     \/ /\ rmState[self] = "working"
+                        /\ rmState' = [rmState EXCEPT ![self] = "aborted"]
+                        /\ msgs' = (msgs \cup {([type |-> "RMAborted"])})
+                     \/ /\ ([type |-> "Commit"]) \in msgs
+                        /\ rmState' = [rmState EXCEPT ![self] = "committed"]
+                        /\ msgs' = msgs
+                     \/ /\ ([type |-> "Abort"]) \in msgs
+                        /\ rmState' = [rmState EXCEPT ![self] = "aborted"]
+                        /\ msgs' = msgs
+                  /\ UNCHANGED << tmState, tmPrepared >>
+
+Next == TManager
+           \/ (\E self \in RM: RManager(self))
+
+Spec == Init /\ [][Next]_vars
+
+\* END TRANSLATION
+
+Message ==
+  [type : {"RMPrepared"}, rm : RM]  \cup  [type : {"RMAborted", "Commit", "Abort"}] \cup [type: {"Propose"}, data: {data}]
+
+TypeOK ==
+  /\ rmState \in [RM -> {"working", "prepared", "committed", "aborted"}]
+  /\ tmState \in {"init", "committed", "aborted"}
+  /\ tmPrepared \subseteq RM  \* \in SUBSET RM
+  /\ msgs \subseteq Message   \* \in SUBSET Message
+
+
+(* invariant for the transaction manager *)
+TMInv == /\ (tmState = "committed") => (tmPrepared = RM)
+         /\ ([type |-> "Commit"] \in msgs) => (tmState = "committed")
+         /\ ([type |-> "Abort"] \in msgs) => (tmState = "aborted")
+
+(* invariant for the resource managers *)
+RMInv(rm) ==
+  /\ (rm \in tmPrepared) => ([type |-> "Prepared", rm |-> rm] \in msgs)
+  /\ ([type |-> "Prepared", rm |-> rm] \in msgs) =>
+         /\ rmState[rm] # "working"
+         /\ (rmState[rm] = "aborted") => ([type |-> "Abort"] \in msgs)
+  /\ (rmState[rm]= "committed") => ([type |-> "Commit"] \in msgs)
+
+Inv == TypeOK /\ TMInv /\ (\A rm \in RM : RMInv(rm))
+
+=============================================================================
+\* Modification History
+\* Last modified Tue Jun 19 14:29:09 PDT 2018 by rmc
+\* Last modified Wed Oct 12 02:41:48 PDT 2011 by lamport
+\* Created Mon Oct 10 06:26:47 PDT 2011 by lamport

--- a/examples/configs/2pc-stateserver.json
+++ b/examples/configs/2pc-stateserver.json
@@ -1,0 +1,20 @@
+{
+  "build": {
+    "output_dir": "gen",
+    "dest_file": "out.go"
+  },
+  "networking": {
+    "enabled": true,
+
+    "state": {
+      "strategy": "state-server",
+      "peers": ["10.0.0.1:12345", "10.0.0.2:12345"]
+    }
+  },
+
+  "constants": {
+    "RM": "1,2,3",
+    "TM": "0",
+    "data": "42"
+  }
+}

--- a/src/pgo/formatters/IssueFormattingVisitor.java
+++ b/src/pgo/formatters/IssueFormattingVisitor.java
@@ -76,7 +76,7 @@ public class IssueFormattingVisitor extends IssueVisitor<Void, IOException> {
 
 	@Override
 	public Void visit(DanglingReferenceIssue danglingReferenceIssue) throws IOException {
-		out.write("could not resolve symbol ");
+		out.write("could not resolve ");
 		danglingReferenceIssue.getFrom().accept(new OriginFormattingVisitor(out));
 		return null;
 	}

--- a/src/pgo/lexer/TLALexer.java
+++ b/src/pgo/lexer/TLALexer.java
@@ -231,7 +231,7 @@ public class TLALexer {
 	static final Pattern COMMENT_END = Pattern.compile("\\*\\)");
 	static final Pattern LINE_COMMENT = Pattern.compile("\\\\\\*");
 	
-	static final Pattern PGO_ANNOTATION = Pattern.compile("@PGo\\{(.*)\\}@PGo");
+	static final Pattern PGO_ANNOTATION = Pattern.compile("@PGo\\{(.*?)}@PGo");
 	
 	static final Pattern BEGIN_TRANSLATION = Pattern.compile("\\\\\\*+ BEGIN TRANSLATION$");
 	static final Pattern END_TRANSLATION = Pattern.compile("\\\\\\*+ END TRANSLATION$");

--- a/test/pgo/lexer/TLALexerTest.java
+++ b/test/pgo/lexer/TLALexerTest.java
@@ -44,9 +44,9 @@ public class TLALexerTest {
 	@Parameters
 	public static List<Object[]> data(){
 		return Arrays.asList(new Object[][] {
-			{ "TRUE", Arrays.asList(tok("TRUE", builtin(), 1, 1)) },
-			{ "FALSE", Arrays.asList(tok("FALSE", builtin(), 1, 1)) },
-			{ "a", Arrays.asList(tok("a", ident(), 1, 1)) },
+			{ "TRUE", Collections.singletonList(tok("TRUE", builtin(), 1, 1))},
+			{ "FALSE", Collections.singletonList(tok("FALSE", builtin(), 1, 1))},
+			{ "a", Collections.singletonList(tok("a", ident(), 1, 1))},
 			{ "a b", Arrays.asList(tok("a", ident(), 1, 1), tok("b", ident(), 3, 1)) },
 			{ "  /\\ a\n  /\\ b\n  /\\ c", Arrays.asList(
 					tok("/\\", builtin(), 3, 1),
@@ -57,8 +57,8 @@ public class TLALexerTest {
 					tok("c", ident(), 6, 3)
 					)
 			},
-			{ ".2", Arrays.asList(tok(".2", num(), 1, 1)) },
-			{ "\"abc.+#\"", Arrays.asList(tok("abc.+#", str(), 1, 1)) },
+			{ ".2", Collections.singletonList(tok(".2", num(), 1, 1))},
+			{ "\"abc.+#\"", Collections.singletonList(tok("abc.+#", str(), 1, 1))},
 			{ "a\n\\* BEGIN TRANSLATION\nb", Arrays.asList(
 					tok("a", ident(), 1, 1),
 					tok("\\* BEGIN TRANSLATION", TLATokenType.BEGIN_TRANSLATION, 1, 2),
@@ -81,9 +81,15 @@ public class TLALexerTest {
 					tok("b", ident(), 1, 3)
 					)
 			},
-			{ "<=", Arrays.asList(tok("<=", builtin(), 1, 1)) },
-			{ "\\** BEGIN TRANSLATION", Arrays.asList(tok("\\** BEGIN TRANSLATION", TLATokenType.BEGIN_TRANSLATION, 1, 1)) },
+			{ "<=", Collections.singletonList(tok("<=", builtin(), 1, 1))},
+			{ "\\** BEGIN TRANSLATION", Collections.singletonList(tok("\\** BEGIN TRANSLATION", TLATokenType.BEGIN_TRANSLATION, 1, 1))},
 			{ "\\notin", Collections.singletonList(tok("\\notin", builtin(), 1, 1))},
+			{ "CONSTANT procs (* @PGo{ arg int }@PGo *), iters (* @PGo{ arg int }@PGo *)",
+					Arrays.asList(
+							tok("CONSTANT", builtin(), 1, 1),
+							tok("procs", ident(), 10, 1),
+							tok(",", builtin(), 41, 1),
+							tok("iters", ident(), 43, 1))},
 		});
 	}
 


### PR DESCRIPTION
I added a `2pc.tla` spec, based on the spec available at: http://lamport.azurewebsites.net/tla/two-phase.html. I made changes to Lamport's original specs, and they are listed in the comments in the top of that file.

Things that are unclear and need to be explored further:

* Compilation of `either`. Instead of pseudo-randomly choosing a branch of `either` statements, we can generate a function where the developer implements the actual application logic that decides which concrete path should be taken.

Example/draft:

Given the following spec:

~~~tla
either { doA() } or { doB() } or { doC() }
~~~

PGo could translate that to:

~~~go
// locals: all variables that are local to the PlusCal process
func Decide(locals) string {
  // app logic
  // returns one of: "doA" or "doB" or "doC"
  
  // by default, it could return a random choice, but hopefully the developer
  // will add code that makes sense in the application where two-phase commit
  // is being used
  return []string{"doA", "doB", "doC"}[rand.Intn(3)]
}

switch decision := Decide(locals) {
case "doA":
  doA(); // expansion of doA macro
case "doB":
  doB(); // expansion of doB macro
case "doC":
  doC(); // expansion of doC macro
default:
  panic("Unknown 'either' branch: %s", decision)
}
~~~

* Network: the original spec uses a set of records. Perhaps a better representation would use sequences

* Type checking does not work for functions defined as `[rm \in RM |-> "working"]`. `\in` is still unsupported.

* Unclear how the code generated by PGo would be integrated in a larger application that wishes to use a two-phase commit protocol for its operation without making significant code changes.