### PR TITLE
Added javadoc to "common vocabulary" TLA+ parser methods

### DIFF
--- a/src/pgo/parser/ParseAction.java
+++ b/src/pgo/parser/ParseAction.java
@@ -1,41 +1,111 @@
 package pgo.parser;
 
+/**
+ * Represents a parsing action that consumes tokens from a {@link pgo.parser.ParseContext} and either successfully
+ * yields a result of type {@code Result} or fails with a {@link pgo.parser.ParseFailure}.
+ * @param <Result> the type of an object representing a successful parse
+ */
 interface ParseAction<Result> {
+
+	/**
+	 * Produces a further parsing action based on an existing parsing result.
+	 * @param <Result> the type of the existing parsing result
+	 * @param <ChainResult> the result type of the new parse action
+	 */
 	interface Operation<Result, ChainResult>{
 		ParseAction<ChainResult> perform(Result r);
 	}
-	
+
+	/**
+	 * A direct mapping between one parsing result and another.
+	 * @param <Result> the type of the original parse result
+	 * @param <ChainResult> the type of the transformed parse result
+	 */
 	interface Mapping<Result, ChainResult>{
 		ChainResult perform(Result r);
 	}
-	
+
+	/**
+	 * Produces an {@link pgo.parser.ActionContext} as part of mechanism defined by
+	 * {@link pgo.parser.ParseAction#withContext}
+	 */
 	interface ContextGenerator{
 		ActionContext getContext();
 	}
 
+	/**
+	 * This method allows chaining of parse actions based on previous parsing results. Whenever a parse action fails,
+	 * no further actions will be attempted and the failure will be propagated as a parse failure.
+	 * @param operation An operation that depends on the result of the current parse action, returning a further parse
+	 *                  action to be performed based on the result of the current parse action.
+	 * @param <ChainResult> the type of the parse action returned by {@code operation.perform}
+	 * @return a new parse action that yields the result of performing this parse action, followed by the parse action
+	 * 	returned by {@code operation.perform(currentResult)}.
+	 */
 	default <ChainResult> ParseAction<ChainResult> chain(Operation<Result, ChainResult> operation){
 		return new ParseActionChain<>(this, operation);
 	}
-	
-	default <ChainResult> ParseAction<ChainResult> map(Mapping<Result, ChainResult> operation){
+
+	/**
+	 * Transforms the result of one ParseAction. Use this method when no further parsing needs to be done, but the
+	 * format of the parsed data structure needs adjusting.
+	 * @param operation a mapping from the actual parse result to an adjusted parse result
+	 * @param <MapResult> the type of the mapped parse action
+	 * @return a new parse action that yields the result of {@code operation.perform(originalResult)}
+	 */
+	default <MapResult> ParseAction<MapResult> map(Mapping<Result, MapResult> operation){
 		return chain(result -> success(operation.perform(result)));
 	}
-	
+
+	/**
+	 * A shorthand for calling {@link pgo.parser.ParseAction#withContext(ContextGenerator)} with {@code () -> ctx}. Use this when the
+	 * context does not depend on the results of executing previous parse actions.
+	 * @param ctx the action's context
+	 * @return a new parse action with the context ctx
+	 */
 	default ParseAction<Result> withContext(ActionContext ctx){
 		return withContext(() -> ctx);
 	}
-	
+
+	/**
+	 * The longhand form of {@link pgo.parser.ParseAction#withContext(ActionContext)}, when the parsing context depends
+	 * on information only available during parsing, not before.
+	 * @param gen produces a context
+	 * @return a new parse action that will have the context created by gen. {@code gen.getContext()} will be called
+	 * 	at parse-time, allowing the context to depend on any previously executed parse actions
+	 */
 	default ParseAction<Result> withContext(ContextGenerator gen){
 		return new ParseActionWithContext<>(this, gen);
 	}
-	
+
+	/**
+	 * A shorthand for generating parsing successes.
+	 * @param result the result of this successful parse
+	 * @param <Result> the type of the result
+	 * @return a parse action that will always succeed, yielding {@code result}
+	 */
 	static <Result> ParseAction<Result> success(Result result){
 		return new ParseActionSuccess<>(result);
 	}
-	
+
+	/**
+	 * A shorthand for generating parsing failures.
+	 * @param failure an object describing the parsing failure
+	 * @param <Result> the type of the expected parsing result (which will never be yielded)
+	 * @return a parse action that always fails with error {@code failure}
+	 */
 	static <Result> ParseAction<Result> failure(ParseFailure failure) {
 		return new ParseActionFailure<>(failure);
 	}
-	
+
+	/**
+	 * Performs the parsing action, returning a result representing either a successful parse or a failure.
+	 *
+	 * This would typically be used either internally or as a top-level call to initiate parsing once a tree of parsing
+	 * actions has been fully constructed.
+	 *
+	 * @param ctx the parsing context on which to operate
+	 * @return the result of attempting this parsing action
+	 */
 	ParseResult<Result> perform(ParseContext ctx);
 }

--- a/src/pgo/parser/ParseTools.java
+++ b/src/pgo/parser/ParseTools.java
@@ -12,18 +12,13 @@ import pgo.util.SourceLocatable;
 public class ParseTools {
 	
 	private ParseTools() {}
-	
-	/*private static SourceLocation getSourceLocation(TLAToken tok) {
-		if(tok.source == null) {
-			return SourceLocation.unknown();
-		}else {
-			PCalLocation begin = tok.source.getBegin();
-			PCalLocation end = tok.source.getEnd();
-			return new SourceLocation(
-					Paths.get("???"), begin.getLine(), end.getLine(), begin.getColumn(), end.getColumn());
-		}
-	}*/
-	
+
+	/**
+	 * Creates a parse action that accepts a token of the specified type, with a minimum column position of minColumn.
+	 * @param tokenType the expected token type
+	 * @param minColumn the minimum accepted column position
+	 * @return the parse action
+	 */
 	public static ParseAction<LocatedString> parseTokenType(TLATokenType tokenType, int minColumn){
 		return ctx -> {
 			TLAToken tok = ctx.readToken();
@@ -38,7 +33,13 @@ public class ParseTools {
 			}
 		};
 	}
-	
+
+	/**
+	 * Creates a parse action that accepts a token with type {@link pgo.lexer.TLATokenType#BUILTIN} and value t
+	 * @param t the string representation that should be accepted
+	 * @param minColumn the minimum column at which to accept a token
+	 * @return the parse action
+	 */
 	public static ParseAction<LocatedString> parseBuiltinToken(String t, int minColumn){
 		return parseTokenType(TLATokenType.BUILTIN, minColumn)
 				.withContext(new WhileParsingBuiltinToken(t))
@@ -51,7 +52,14 @@ public class ParseTools {
 					}
 				});
 	}
-	
+
+	/**
+	 * Creates a parse action that accepts a token with type {@link pgo.lexer.TLATokenType#BUILTIN} and a value that is
+	 * one of options
+	 * @param options a list of acceptable token values
+	 * @param minColumn the minimum column at which to accept a token
+	 * @return the parse action
+	 */
 	public static ParseAction<LocatedString> parseBuiltinTokenOneOf(List<String> options, int minColumn){
 		return parseTokenType(TLATokenType.BUILTIN, minColumn)
 				.chain(s -> {
@@ -63,33 +71,80 @@ public class ParseTools {
 					}
 				});
 	}
-	
+
+	/**
+	 * Creates a parse action that accepts a token with type {@link pgo.lexer.TLATokenType#IDENT}.
+	 * @param minColumn the minimum column at which to accept a token
+	 * @return the parse action
+	 */
 	public static ParseAction<PGoTLAIdentifier> parseIdentifier(int minColumn){
 		return parseTokenType(TLATokenType.IDENT, minColumn)
 				.map(s -> new PGoTLAIdentifier(s.getLocation(), s.getValue()));
 	}
-	
+
+	/**
+	 * Creates a parse action that accepts a token with type {@link pgo.lexer.TLATokenType#STRING}.
+	 * @param minColumn the minimum column at which to accept a token
+	 * @return the parse action
+	 */
 	public static ParseAction<LocatedString> parseString(int minColumn){
 		return parseTokenType(TLATokenType.STRING, minColumn);
 	}
-	
+
+	/**
+	 * Creates a parse action that accepts a token with type {@link pgo.lexer.TLATokenType#NUMBER}.
+	 * @param minColumn the minimum column at which to accept a token
+	 * @return the parse action
+	 */
 	public static ParseAction<LocatedString> parseNumber(int minColumn){
 		return parseTokenType(TLATokenType.NUMBER, minColumn);
 	}
-	
+
+	/**
+	 * Combines parse actions from the list of options into one single parse action. Each action will be tried in the
+	 * same order as in the list, and the first successful action's result will be yielded. If none of the actions match
+	 * the entire set of parse failures will be yielded.
+	 * @param options a list of parse actions to try
+	 * @param <Result> the common result type of all the parse actions
+	 * @return the combined parse action
+	 */
 	public static <Result> ParseAction<Result> parseOneOf(List<ParseAction<? extends Result>> options){
 		return new ParseActionOneOf<Result>(options);
 	}
-	
+
+	/**
+	 * The varargs version of {@link pgo.parser.ParseTools#parseOneOf(List<ParseAction<? extends Result>)}.
+	 * @param options an array of parse actions to try
+	 * @param <Result> the common result type of all the parse actions
+	 * @return the combined parse action
+	 */
 	@SafeVarargs
 	public static <Result> ParseAction<Result> parseOneOf(ParseAction<? extends Result>... options){
 		return parseOneOf(Arrays.asList(options));
 	}
-	
+
+	/**
+	 * <p>Creates a parse action that repeatedly attempts the parse action element until it fails. The result of each
+	 * attempt will be combined into a {@link pgo.parser.LocatedList}. This action has a similar behaviour to
+	 * the Kleene star (*).</p>
+	 *
+	 * <p>
+	 *     Note: the source locations of each element will be combined and presented as the location of the LocatedList
+	 * </p>
+	 * @param element the parse action to repeat
+	 * @param <Result> the element type of the resulting LocatedList
+	 * @return the parse action
+	 */
 	public static <Result extends SourceLocatable> ParseAction<LocatedList<Result>> repeat(ParseAction<Result> element){
 		return new ParseActionRepeated<Result>(element);
 	}
-	
+
+	/**
+	 * Similar to {@link pgo.parser.ParseTools#repeat(ParseAction<Result>)}, but only accepting sequences of at least one element.
+	 * @param element a parse action representing one element of the list
+	 * @param <Result> the element type of the resulting LocatedList
+	 * @return the parse action
+	 */
 	public static <Result extends SourceLocatable> ParseAction<LocatedList<Result>> repeatOneOrMore(ParseAction<Result> element){
 		Mutator<Result> first = new Mutator<>();
 		Mutator<LocatedList<Result>> rest = new Mutator<>();
@@ -102,23 +157,98 @@ public class ParseTools {
 					return rest.getValue();
 				});
 	}
-	
+
+	/**
+	 * <p>A tool for expressing a sequence of consecutive parse actions.</p>
+	 *
+	 * <p>In order to work better within the context of Java, we do some unusual things here. The sequence of actions
+	 * is expressed as a series of {@link pgo.parser.ParseActionSequence.Part} objects. Here is some example code:</p>
+	 *
+	 * <pre>{@code
+	 * Mutator<Result> mut = new Mutator<>();
+	 *
+	 * return sequence(
+	 * 		drop(parseX()),
+	 * 		part(mut, parseY()),
+	 * 		drop(parseZ()
+	 * ).map(result -> {
+	 * 		return new ASTNode(result.getLocation(), mut.getValue());
+	 * });
+	 * }</pre>
+	 *
+	 * <p>
+	 * In this example we create a parse action that accepts a sequence of X, Y and Z. The values of X and Z do not
+	 * matter, perhaps as they are just built-in constants like punctuation. As such, we
+	 * {@link pgo.parser.ParseTools#drop} them. They will still be required for parsing to succeed but
+	 * their values are dropped. The item of interest, Y, does need storing so we indicate we are interested using
+	 * {@link pgo.parser.ParseTools#part}. The result of parsing Y will be stored in the
+	 * {@link pgo.parser.Mutator} mut.
+	 * </p>
+	 *
+	 * <p>
+	 * Since for accurate source location tracking we want to know the location of everything we parsed,
+	 * {@link pgo.parser.ParseActionSequence} yields a {@link pgo.parser.ParseActionSequenceResult} which holds metadata
+	 * for the entire parse including dropped elements, currently only the entire source location.
+	 * </p>
+	 *
+	 * @param parts a list of parts of the sequence to parse
+	 * @see pgo.parser.ParseTools#sequence(ParseActionSequence.Part...)
+	 * @return a parse action that will yield parse metadata for the entire sequence, use mutators and
+	 * 		{@link pgo.parser.ParseAction#map} to transform this result into the desired data structure as described
+	 * 		above.
+	 */
 	public static ParseAction<ParseActionSequenceResult> sequence(List<ParseActionSequence.Part> parts){
 		return new ParseActionSequence(parts);
 	}
-	
+
+	/**
+	 * The varargs version of {@link pgo.parser.ParseTools#sequence(List<ParseActionSequence.Part)}
+	 * @param parts an array of sequence parts, representing the sequence the parse action should recognise
+	 * @return the parse action
+	 */
 	public static ParseAction<ParseActionSequenceResult> sequence(ParseActionSequence.Part... parts){
 		return sequence(Arrays.asList(parts));
 	}
-	
+
+	/**
+	 * Creates a {@link pgo.parser.ParseActionSequence.Part}. This represents a part of the sequence that is of interest.
+	 * @param mutator the mutator in which to store the result of parsing this part of the sequence
+	 * @param action the parse action to execute as this part of the sequence
+	 * @param <Result> the type of the parse action's result (also the type of the mutator's value)
+	 * @return a part of a parse action sequence
+	 */
 	public static <Result extends SourceLocatable> ParseActionSequence.Part part(Mutator<Result> mutator, ParseAction<Result> action){
 		return ParseActionSequence.part(mutator, action);
 	}
-	
+
+	/**
+	 * Creates a part of a {@link pgo.parser.ParseActionSequence}. This represents a part of a sequence that is not of
+	 * interest but still part of the grammar like punctuation, brackets, etc...
+	 *
+	 * Executes the parse action then discards the result.
+	 *
+	 * @param action the parse action to execute
+	 * @param <Result> the type of the discarded result
+	 * @return a part of a parse action sequence
+	 */
 	public static <Result extends SourceLocatable> ParseActionSequence.Part drop(ParseAction<Result> action){
 		return ParseActionSequence.part(new DropMutator<Result>(), action);
 	}
-	
+
+	/**
+	 * <p>
+	 * Useful for dealing with some subtleties of parse actions - for example, recursive parse actions (and thus
+	 * recursive grammars) cannot be directly represented as they will consume infinite space. You can work around this
+	 * by prefixing the recursive call with {@code nop()} like this: {@code nop().chain(v -> yourRecursiveCall(...))}.
+	 * </p>
+	 *
+	 * <p>
+	 * This ensures that the recursive parse action will only be instantiated upon control flow reaching the recursive
+	 * call.
+	 * </p>
+	 *
+	 * @return a parse action that successfully parses no tokens and yields null.
+	 */
 	public static ParseAction<Void> nop(){
 		return ParseAction.success(null);
 	}


### PR DESCRIPTION
This is my attempt at clarifying how the TLA+ parser works - let me know if it makes sense.

There are no intended feature changes. Addresses #54 .