### PR TITLE
Add support for case expressions. Add failure tests.

### DIFF
--- a/src/pgo/trans/intermediate/TLAExpressionCodeGenVisitor.java
+++ b/src/pgo/trans/intermediate/TLAExpressionCodeGenVisitor.java
@@ -172,13 +172,8 @@ public class TLAExpressionCodeGenVisitor extends PGoTLAExpressionVisitor<Express
 
 	@Override
 	public Expression visit(PGoTLACase pGoTLACase) throws RuntimeException {
-		VariableName result = null;
-		if (pGoTLACase.getOther() != null) {
-			result = builder.varDecl("result", pGoTLACase.getOther().accept(this));
-		} else {
-			UID uid = pGoTLACase.getArms().get(0).getResult().getUID();
-			result = builder.varDecl("result", typeMap.get(uid).accept(new PGoTypeGoTypeConversionVisitor()));
-		}
+		UID uid = pGoTLACase.getArms().get(0).getResult().getUID();
+		VariableName result = builder.varDecl("result", typeMap.get(uid).accept(new PGoTypeGoTypeConversionVisitor()));
 		LabelName matched = builder.newLabel("matched");
 
 		for (PGoTLACaseArm caseArm : pGoTLACase.getArms()) {
@@ -192,6 +187,8 @@ public class TLAExpressionCodeGenVisitor extends PGoTLAExpressionVisitor<Express
 
 		if (pGoTLACase.getOther() == null) {
 			builder.addPanic(new StringLiteral("No matching case!"));
+		} else {
+			builder.assign(result, pGoTLACase.getOther().accept(this));
 		}
 
 		builder.label(matched);

--- a/src/pgo/trans/passes/type/TLAExpressionTypeConstraintVisitor.java
+++ b/src/pgo/trans/passes/type/TLAExpressionTypeConstraintVisitor.java
@@ -123,7 +123,17 @@ public class TLAExpressionTypeConstraintVisitor extends PGoTLAExpressionVisitor<
 
 	@Override
 	public PGoType visit(PGoTLACase pGoTLACase) throws RuntimeException {
-		throw new TODO();
+		PGoTypeVariable v = generator.get();
+		for (PGoTLACaseArm caseArm : pGoTLACase.getArms()) {
+			solver.addConstraint(new PGoTypeMonomorphicConstraint(pGoTLACase, wrappedVisit(caseArm.getCondition()), new PGoTypeBool(Collections.singletonList(caseArm.getCondition()))));
+			solver.addConstraint(new PGoTypeMonomorphicConstraint(pGoTLACase, wrappedVisit(caseArm.getResult()), v));
+		}
+
+		if (pGoTLACase.getOther() != null) {
+			solver.addConstraint(new PGoTypeMonomorphicConstraint(pGoTLACase, wrappedVisit(pGoTLACase.getOther()), v));
+		}
+
+		return v;
 	}
 
 	@Override

--- a/test/pgo/ExpressionCodeGenRunFailureTest.java
+++ b/test/pgo/ExpressionCodeGenRunFailureTest.java
@@ -1,0 +1,49 @@
+package pgo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import pgo.model.tla.PGoTLAExpression;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static pgo.model.tla.Builder.*;
+
+@RunWith(Parameterized.class)
+public class ExpressionCodeGenRunFailureTest {
+	static IntegrationTestingUtils.KeyValue kv(String key, PGoTLAExpression value) {
+		return new IntegrationTestingUtils.KeyValue(key, value);
+	}
+
+	@Parameters
+	public static List<Object[]> data(){
+		return Arrays.asList(new Object[][] {
+			// if expression tests
+			{
+				caseexp(arms(arm(bool(false), str("Hello world"))), null),
+				Arrays.asList(),
+				Collections.singletonList("panic: No matching case!"),
+			},
+		});
+	}
+
+	private PGoTLAExpression result;
+	private List<IntegrationTestingUtils.KeyValue> vars;
+	private List<String> expected;
+
+	public ExpressionCodeGenRunFailureTest(PGoTLAExpression result, List<IntegrationTestingUtils.KeyValue> vars, List<String> expected) {
+		this.result = result;
+		this.vars = vars;
+		this.expected = expected;
+	}
+
+	@Test
+	public void test() throws IOException {
+		// try to run the compiled Go code, check that it prints the right thing
+		IntegrationTestingUtils.testCompileExpression(result, vars, expected, true);
+	}
+}

--- a/test/pgo/ExpressionCodeGenRunFailureTest.java
+++ b/test/pgo/ExpressionCodeGenRunFailureTest.java
@@ -44,6 +44,7 @@ public class ExpressionCodeGenRunFailureTest {
 	@Test
 	public void test() throws IOException {
 		// try to run the compiled Go code, check that it prints the right thing
-		IntegrationTestingUtils.testCompileExpression(result, vars, expected, true);
+		IntegrationTestingUtils.testCompileExpression(result, vars, compiledOutputPath ->
+			IntegrationTestingUtils.testRunGoCodeShouldPanic(compiledOutputPath, expected));
 	}
 }

--- a/test/pgo/ExpressionCodeGenRunTest.java
+++ b/test/pgo/ExpressionCodeGenRunTest.java
@@ -23,33 +23,47 @@ import static pgo.model.tla.Builder.*;
 
 @RunWith(Parameterized.class)
 public class ExpressionCodeGenRunTest {
-
-	static class KeyValue {
-		private String key;
-		private PGoTLAExpression value;
-
-		public KeyValue(String key, PGoTLAExpression value) {
-			super();
-			this.key = key;
-			this.value = value;
-		}
-
-		public String getKey() {
-			return key;
-		}
-
-		public PGoTLAExpression getValue() {
-			return value;
-		}
-	}
-
-	static KeyValue kv(String key, PGoTLAExpression value) {
-		return new KeyValue(key, value);
+	static IntegrationTestingUtils.KeyValue kv(String key, PGoTLAExpression value) {
+		return new IntegrationTestingUtils.KeyValue(key, value);
 	}
 
 	@Parameters
 	public static List<Object[]> data(){
 		return Arrays.asList(new Object[][] {
+			// case expression tests
+			{
+				caseexp(arms(
+						arm(binop("=", idexp("a"), num(1)), str("a = 1")),
+						arm(binop("=", idexp("a"), num(2)), str("a = 2")),
+						arm(binop("=", idexp("a"), num(3)), str("a = 3")),
+						arm(binop("=", idexp("a"), num(4)), str("a = 4")),
+						arm(binop("=", idexp("a"), num(5)), str("a = 5"))
+				), str("a > 5 or a < 0")),
+				Arrays.asList(kv("a", num(3))),
+				Collections.singletonList("a = 3"),
+			},
+			{
+				caseexp(arms(
+						arm(binop("=", idexp("a"), num(1)), str("a = 1")),
+						arm(binop("=", idexp("a"), num(2)), str("a = 2")),
+						arm(binop("=", idexp("a"), num(3)), str("a = 3")),
+						arm(binop("=", idexp("a"), num(4)), str("a = 4")),
+						arm(binop("=", idexp("a"), num(5)), str("a = 5"))
+				), str("a > 5 or a < 0")),
+				Arrays.asList(kv("a", num(11))),
+				Collections.singletonList("a > 5 or a < 0"),
+			},
+			{
+				caseexp(arms(
+						arm(binop("=", idexp("a"), num(1)), str("a = 1")),
+						arm(binop("=", idexp("a"), num(2)), str("a = 2")),
+						arm(binop("=", idexp("a"), num(3)), str("a = 3")),
+						arm(binop("=", idexp("a"), num(4)), str("a = 4")),
+						arm(binop("=", idexp("a"), num(5)), str("a = 5"))
+				), null),
+				Arrays.asList(kv("a", num(3))),
+				Collections.singletonList("a = 3"),
+			},
 			// if expression tests
 			{
 				ifexp(bool(true), str("Then Branch"), str("Else Branch")),
@@ -57,9 +71,9 @@ public class ExpressionCodeGenRunTest {
 				Collections.singletonList("Then Branch"),
 			},
 			{
-					ifexp(bool(false), str("Then Branch"), str("Else Branch")),
-					Arrays.asList(),
-					Collections.singletonList("Else Branch"),
+				ifexp(bool(false), str("Then Branch"), str("Else Branch")),
+				Arrays.asList(),
+				Collections.singletonList("Else Branch"),
 			},
 			{
 				ifexp(binop(">", idexp("a"), idexp("b")), idexp("a"), idexp("b")),
@@ -181,10 +195,10 @@ public class ExpressionCodeGenRunTest {
 	}
 
 	private PGoTLAExpression result;
-	private List<KeyValue> vars;
+	private List<IntegrationTestingUtils.KeyValue> vars;
 	private List<String> expected;
 
-	public ExpressionCodeGenRunTest(PGoTLAExpression result, List<KeyValue> vars, List<String> expected) {
+	public ExpressionCodeGenRunTest(PGoTLAExpression result, List<IntegrationTestingUtils.KeyValue> vars, List<String> expected) {
 		this.result = result;
 		this.vars = vars;
 		this.expected = expected;
@@ -192,88 +206,7 @@ public class ExpressionCodeGenRunTest {
 
 	@Test
 	public void test() throws IOException {
-		Path tempDirPath = Files.createTempDirectory("pgotest");
-		File tempDir = tempDirPath.toFile();
-		Path generatedCodePath = tempDirPath.resolve("Test.tla");
-		Path generatedConfigPath = tempDirPath.resolve("config.json");
-
-		Path compiledOutputPath = tempDirPath.resolve("test.go");
-		try{
-			// generate test TLA+ file
-			try(BufferedWriter w = Files.newBufferedWriter(generatedCodePath);
-					IndentingWriter out = new IndentingWriter(w);){
-				out.write("---- MODULE Test ----");
-				out.newLine();
-				out.write("EXTENDS Sequences, Integers");
-				out.newLine();
-
-				out.write("(* --algorithm Test {");
-				out.newLine();
-				try(IndentingWriter.Indent i_ = out.indent()){
-					if(!vars.isEmpty()) {
-						out.write("variables ");
-						try(IndentingWriter.Indent i2_ = out.indentToPosition()){
-							for(KeyValue var : vars) {
-								out.write(var.getKey());
-								out.write(" = ");
-								var.getValue().accept(new PGoTLAExpressionFormattingVisitor(out));
-								out.write(";");
-								out.newLine();
-							}
-						}
-					}
-					out.write("{");
-					out.newLine();
-					try(IndentingWriter.Indent i2_ = out.indent()){
-						out.write("print ");
-						result.accept(new PGoTLAExpressionFormattingVisitor(out));
-					}
-					out.newLine();
-					out.write("}");
-				}
-				out.newLine();
-				out.write("}");
-				out.newLine();
-				out.write("*)");
-
-				out.newLine();
-				out.write("====");
-			}
-
-			// generate config file
-			try(BufferedWriter w = Files.newBufferedWriter(generatedConfigPath)){
-				JSONObject config = new JSONObject();
-
-				JSONObject build = new JSONObject();
-				build.put("output_dir", tempDirPath.toString());
-				build.put("dest_file", "test.go");
-				config.put("build", build);
-
-				JSONObject networking = new JSONObject();
-				networking.put("enabled", false);
-				config.put("networking", networking);
-
-				config.write(w);
-			}
-
-			// invoke the compiler
-			PGoMain.main(new String[] {
-					"-c",
-					generatedConfigPath.toString(),
-					generatedCodePath.toString(),
-			});
-
-			// display the compiled code for inspection
-			Files.lines(compiledOutputPath).forEach(line -> {
-				System.out.println("source: "+line);
-			});
-
-			// try to run the compiled Go code, check that it prints the right thing
-			IntegrationTestingUtils.testRunGoCode(compiledOutputPath, expected);
-
-		} finally {
-			IntegrationTestingUtils.expungeFile(tempDir);
-		}
+		// try to run the compiled Go code, check that it prints the right thing
+		IntegrationTestingUtils.testCompileExpression(result, vars, expected, false);
 	}
-
 }

--- a/test/pgo/ExpressionCodeGenRunTest.java
+++ b/test/pgo/ExpressionCodeGenRunTest.java
@@ -1,22 +1,15 @@
 package pgo;
 
-import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import pgo.formatters.IndentingWriter;
-import pgo.formatters.PGoTLAExpressionFormattingVisitor;
 import pgo.model.tla.PGoTLAExpression;
 
 import static pgo.model.tla.Builder.*;
@@ -207,6 +200,7 @@ public class ExpressionCodeGenRunTest {
 	@Test
 	public void test() throws IOException {
 		// try to run the compiled Go code, check that it prints the right thing
-		IntegrationTestingUtils.testCompileExpression(result, vars, expected, false);
+		IntegrationTestingUtils.testCompileExpression(result, vars, compiledOutputPath ->
+			IntegrationTestingUtils.testRunGoCode(compiledOutputPath, expected));
 	}
 }

--- a/test/pgo/IntegrationTestingUtils.java
+++ b/test/pgo/IntegrationTestingUtils.java
@@ -1,13 +1,15 @@
 package pgo;
 
+import org.json.JSONObject;
+import pgo.formatters.IndentingWriter;
+import pgo.formatters.PGoTLAExpressionFormattingVisitor;
+import pgo.model.tla.PGoTLAExpression;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,6 +17,25 @@ import java.util.stream.Collectors;
 public class IntegrationTestingUtils {
 	
 	private IntegrationTestingUtils() {}
+
+	static class KeyValue {
+		private String key;
+		private PGoTLAExpression value;
+
+		public KeyValue(String key, PGoTLAExpression value) {
+			super();
+			this.key = key;
+			this.value = value;
+		}
+
+		public String getKey() {
+			return key;
+		}
+
+		public PGoTLAExpression getValue() {
+			return value;
+		}
+	}
 	
 	public static void expungeFile(File file) {
 		if(file.isDirectory()) {
@@ -24,6 +45,97 @@ public class IntegrationTestingUtils {
 		}
 		if(!file.delete()) {
 			System.err.println("WARNING: could not delete file "+file+"; check your temp folder");
+		}
+	}
+
+	public static void testCompileExpression(PGoTLAExpression result, List<KeyValue> vars,
+											 List<String> expected, Boolean panic) throws IOException {
+		Path tempDirPath = Files.createTempDirectory("pgotest");
+		File tempDir = tempDirPath.toFile();
+		Path generatedCodePath = tempDirPath.resolve("Test.tla");
+		Path generatedConfigPath = tempDirPath.resolve("config.json");
+
+		Path compiledOutputPath = tempDirPath.resolve("test.go");
+		try{
+			// generate test TLA+ file
+			try(BufferedWriter w = Files.newBufferedWriter(generatedCodePath);
+				IndentingWriter out = new IndentingWriter(w);){
+				out.write("---- MODULE Test ----");
+				out.newLine();
+				out.write("EXTENDS Sequences, Integers");
+				out.newLine();
+
+				out.write("(* --algorithm Test {");
+				out.newLine();
+				try(IndentingWriter.Indent i_ = out.indent()){
+					if(!vars.isEmpty()) {
+						out.write("variables ");
+						try(IndentingWriter.Indent i2_ = out.indentToPosition()){
+							for(KeyValue var : vars) {
+								out.write(var.getKey());
+								out.write(" = ");
+								var.getValue().accept(new PGoTLAExpressionFormattingVisitor(out));
+								out.write(";");
+								out.newLine();
+							}
+						}
+					}
+					out.write("{");
+					out.newLine();
+					try(IndentingWriter.Indent i2_ = out.indent()){
+						out.write("print ");
+						result.accept(new PGoTLAExpressionFormattingVisitor(out));
+					}
+					out.newLine();
+					out.write("}");
+				}
+				out.newLine();
+				out.write("}");
+				out.newLine();
+				out.write("*)");
+
+				out.newLine();
+				out.write("====");
+			}
+
+			// generate config file
+			try(BufferedWriter w = Files.newBufferedWriter(generatedConfigPath)){
+				JSONObject config = new JSONObject();
+
+				JSONObject build = new JSONObject();
+				build.put("output_dir", tempDirPath.toString());
+				build.put("dest_file", "test.go");
+				config.put("build", build);
+
+				JSONObject networking = new JSONObject();
+				networking.put("enabled", false);
+				config.put("networking", networking);
+
+				config.write(w);
+			}
+
+			// invoke the compiler
+			PGoMain.main(new String[] {
+					"-c",
+					generatedConfigPath.toString(),
+					generatedCodePath.toString(),
+			});
+
+			// display the compiled code for inspection
+			Files.lines(compiledOutputPath).forEach(line -> {
+				System.out.println("source: "+line);
+			});
+
+			System.out.println("Got here ok");
+
+			// try to run the compiled Go code, check that it prints the right thing
+			if (!panic) {
+				IntegrationTestingUtils.testRunGoCode(compiledOutputPath, expected);
+			} else {
+				IntegrationTestingUtils.testRunGoCodeShouldPanic(compiledOutputPath, expected);
+			}
+		} finally {
+			IntegrationTestingUtils.expungeFile(tempDir);
 		}
 	}
 	
@@ -44,6 +156,18 @@ public class IntegrationTestingUtils {
 				BufferedReader bw = new BufferedReader(r)){
 			List<String> lines = bw.lines().collect(Collectors.toList());
 			assertThat(lines, is(expected));
+		}
+	}
+
+	public static void testRunGoCodeShouldPanic(Path codePath, List<String> expected) throws IOException {
+		// try to run the compiled Go code, check that it panics
+		ProcessBuilder pb = new ProcessBuilder("go", "run", codePath.toString());
+		Process p = pb.start();
+		try(InputStream err = p.getErrorStream();
+			InputStreamReader r = new InputStreamReader(err);
+			BufferedReader bw = new BufferedReader(r)){
+			List<String> lines = bw.lines().collect(Collectors.toList());
+			assertThat(lines.subList(0, expected.size()), is(expected));
 		}
 	}
 

--- a/test/pgo/IntegrationTestingUtils.java
+++ b/test/pgo/IntegrationTestingUtils.java
@@ -36,6 +36,10 @@ public class IntegrationTestingUtils {
 			return value;
 		}
 	}
+
+	public interface TestRunner<T> {
+		public void run(T t) throws IOException;
+	}
 	
 	public static void expungeFile(File file) {
 		if(file.isDirectory()) {
@@ -48,8 +52,9 @@ public class IntegrationTestingUtils {
 		}
 	}
 
+	// See testRunGoCode and testRunGoCodeShouldPanic below for runner examples
 	public static void testCompileExpression(PGoTLAExpression result, List<KeyValue> vars,
-											 List<String> expected, Boolean panic) throws IOException {
+											 TestRunner<Path> runner) throws IOException {
 		Path tempDirPath = Files.createTempDirectory("pgotest");
 		File tempDir = tempDirPath.toFile();
 		Path generatedCodePath = tempDirPath.resolve("Test.tla");
@@ -126,14 +131,8 @@ public class IntegrationTestingUtils {
 				System.out.println("source: "+line);
 			});
 
-			System.out.println("Got here ok");
-
 			// try to run the compiled Go code, check that it prints the right thing
-			if (!panic) {
-				IntegrationTestingUtils.testRunGoCode(compiledOutputPath, expected);
-			} else {
-				IntegrationTestingUtils.testRunGoCodeShouldPanic(compiledOutputPath, expected);
-			}
+			runner.run(compiledOutputPath);
 		} finally {
 			IntegrationTestingUtils.expungeFile(tempDir);
 		}


### PR DESCRIPTION
I implemented the case expression using a series of if statements and gotos (thanks to Finn for the goto idea), which I think is the most readable of the various ways it could have been implemented. The other was handled by setting the default value of the result variable when the other arm is present, and adding a panic if no cases match otherwise.

I implemented failure testing for expected panics, but the logic is still rather rudimentary. Let me know if you want me to fix it up.