### PR TITLE
Procedures in P-syntax

### DIFF
--- a/src/pgo/parser/PlusCalParser.java
+++ b/src/pgo/parser/PlusCalParser.java
@@ -594,7 +594,9 @@ public final class PlusCalParser {
 			.drop(parsePlusCalToken("macro"))
 			.part(IDENTIFIER)
 			.drop(parsePlusCalToken("("))
-			.part(parseListOf(IDENTIFIER, parsePlusCalToken(",")))
+			.part(parseOneOf(
+					parseListOf(IDENTIFIER, parsePlusCalToken(",")),
+					nop().map(v -> new LocatedList<Located<String>>(v.getLocation(), Collections.emptyList()))))
 			.drop(parsePlusCalToken(")"))
 			.drop(parsePlusCalToken("begin"))
 			.part(repeatOneOrMore(P_SYNTAX_STMT))
@@ -611,9 +613,15 @@ public final class PlusCalParser {
 			.drop(parsePlusCalToken("procedure"))
 			.part(IDENTIFIER)
 			.drop(parsePlusCalToken("("))
-			.part(repeatOneOrMore(PVARDECL))
+			.part(parseOneOf(
+					parseListOf(PVARDECL, parsePlusCalToken(",")),
+					nop().map(v -> new LocatedList<PlusCalVariableDeclaration>(v.getLocation(), Collections.emptyList()))
+			))
 			.drop(parsePlusCalToken(")"))
-			.part(parseOneOf(PVARDECLS, nop().map(v -> null)))
+			.part(parseOneOf(
+					PVARDECLS,
+					nop().map(v -> new LocatedList<PlusCalVariableDeclaration>(v.getLocation(), Collections.emptyList()))
+			))
 			.drop(parsePlusCalToken("begin"))
 			.part(repeatOneOrMore(P_SYNTAX_STMT))
 			.drop(parsePlusCalToken("end"))

--- a/test/integration/ProceduresPSyntax.tla
+++ b/test/integration/ProceduresPSyntax.tla
@@ -1,0 +1,150 @@
+---------------------------- MODULE ProceduresPSyntax ----------------------------
+EXTENDS Integers, Sequences, TLC
+
+CONSTANT N
+
+(***************************************************************************
+--algorithm ProcPSyntax
+    variable n = 0;
+
+    macro PrintNum(num) begin
+        print num;
+    end macro;
+
+    procedure Fizz() begin
+        p: print "fizz";
+        return;
+    end procedure;
+
+    procedure Buzz() begin
+        p: print "buzz";
+        return;
+    end procedure;
+
+    procedure FizzBuzz() begin
+        p: print "fizzbuzz";
+        return;
+    end procedure;
+
+    procedure RunFizzBuzz(k) begin
+        check: if ((k % 3 = 0) /\ (k % 5 = 0)) then
+                   call FizzBuzz();
+               elsif (k % 3 = 0) then
+                   call Fizz();
+               elsif (k % 5 = 0) then
+                   call Buzz();
+               else
+                   PrintNum(k);
+               end if;
+
+        ret: return;
+    end procedure;
+
+    process Dummy = 0 begin
+        l1: while (n < N) do
+            inc: n := n + 1;
+            call RunFizzBuzz(n);
+        end while;
+    end process
+end algorithm
+
+ ***************************************************************************)
+\* BEGIN TRANSLATION
+\* Label p of procedure Fizz at line 15 col 12 changed to p_
+\* Label p of procedure Buzz at line 20 col 12 changed to p_B
+CONSTANT defaultInitValue
+VARIABLES n, pc, stack, k
+
+vars == << n, pc, stack, k >>
+
+ProcSet == {0}
+
+Init == (* Global variables *)
+        /\ n = 0
+        (* Procedure RunFizzBuzz *)
+        /\ k = [ self \in ProcSet |-> defaultInitValue]
+        /\ stack = [self \in ProcSet |-> << >>]
+        /\ pc = [self \in ProcSet |-> "l1"]
+
+p_(self) == /\ pc[self] = "p_"
+            /\ PrintT("fizz")
+            /\ pc' = [pc EXCEPT ![self] = Head(stack[self]).pc]
+            /\ stack' = [stack EXCEPT ![self] = Tail(stack[self])]
+            /\ UNCHANGED << n, k >>
+
+Fizz(self) == p_(self)
+
+p_B(self) == /\ pc[self] = "p_B"
+             /\ PrintT("buzz")
+             /\ pc' = [pc EXCEPT ![self] = Head(stack[self]).pc]
+             /\ stack' = [stack EXCEPT ![self] = Tail(stack[self])]
+             /\ UNCHANGED << n, k >>
+
+Buzz(self) == p_B(self)
+
+p(self) == /\ pc[self] = "p"
+           /\ PrintT("fizzbuzz")
+           /\ pc' = [pc EXCEPT ![self] = Head(stack[self]).pc]
+           /\ stack' = [stack EXCEPT ![self] = Tail(stack[self])]
+           /\ UNCHANGED << n, k >>
+
+FizzBuzz(self) == p(self)
+
+check(self) == /\ pc[self] = "check"
+               /\ IF ((k[self] % 3 = 0) /\ (k[self] % 5 = 0))
+                     THEN /\ stack' = [stack EXCEPT ![self] = << [ procedure |->  "FizzBuzz",
+                                                                   pc        |->  "ret" ] >>
+                                                               \o stack[self]]
+                          /\ pc' = [pc EXCEPT ![self] = "p"]
+                     ELSE /\ IF (k[self] % 3 = 0)
+                                THEN /\ stack' = [stack EXCEPT ![self] = << [ procedure |->  "Fizz",
+                                                                              pc        |->  "ret" ] >>
+                                                                          \o stack[self]]
+                                     /\ pc' = [pc EXCEPT ![self] = "p_"]
+                                ELSE /\ IF (k[self] % 5 = 0)
+                                           THEN /\ stack' = [stack EXCEPT ![self] = << [ procedure |->  "Buzz",
+                                                                                         pc        |->  "ret" ] >>
+                                                                                     \o stack[self]]
+                                                /\ pc' = [pc EXCEPT ![self] = "p_B"]
+                                           ELSE /\ PrintT(k[self])
+                                                /\ pc' = [pc EXCEPT ![self] = "ret"]
+                                                /\ stack' = stack
+               /\ UNCHANGED << n, k >>
+
+ret(self) == /\ pc[self] = "ret"
+             /\ pc' = [pc EXCEPT ![self] = Head(stack[self]).pc]
+             /\ k' = [k EXCEPT ![self] = Head(stack[self]).k]
+             /\ stack' = [stack EXCEPT ![self] = Tail(stack[self])]
+             /\ n' = n
+
+RunFizzBuzz(self) == check(self) \/ ret(self)
+
+l1 == /\ pc[0] = "l1"
+      /\ IF (n < N)
+            THEN /\ pc' = [pc EXCEPT ![0] = "inc"]
+            ELSE /\ pc' = [pc EXCEPT ![0] = "Done"]
+      /\ UNCHANGED << n, stack, k >>
+
+inc == /\ pc[0] = "inc"
+       /\ n' = n + 1
+       /\ /\ k' = [k EXCEPT ![0] = n']
+          /\ stack' = [stack EXCEPT ![0] = << [ procedure |->  "RunFizzBuzz",
+                                                pc        |->  "l1",
+                                                k         |->  k[0] ] >>
+                                            \o stack[0]]
+       /\ pc' = [pc EXCEPT ![0] = "check"]
+
+Dummy == l1 \/ inc
+
+Next == Dummy
+           \/ (\E self \in ProcSet:  \/ Fizz(self) \/ Buzz(self) \/ FizzBuzz(self)
+                                     \/ RunFizzBuzz(self))
+           \/ (* Disjunct to prevent deadlock on termination *)
+              ((\A self \in ProcSet: pc[self] = "Done") /\ UNCHANGED vars)
+
+Spec == Init /\ [][Next]_vars
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION
+=============================================================================

--- a/test/integration/SingleProcess.tla
+++ b/test/integration/SingleProcess.tla
@@ -1,0 +1,152 @@
+---------------------------- MODULE SingleProcess ----------------------------
+EXTENDS Integers, Sequences, TLC
+
+CONSTANT N
+
+(***************************************************************************
+--algorithm SingleProcess
+{
+    variable n = 0;
+
+    macro PrintNum(num) {
+        print num;
+    }
+
+    procedure Fizz() {
+        p: print "fizz";
+        return;
+    }
+
+    procedure Buzz() {
+        p: print "buzz";
+        return;
+    }
+
+    procedure FizzBuzz() {
+        p: print "fizzbuzz";
+        return;
+    }
+
+    procedure RunFizzBuzz(k, n1, n2) {
+        check: if ((k % n1 = 0) /\ (k % n2 = 0)) {
+                   call FizzBuzz();
+               } else if (k % 3 = 0) {
+                   call Fizz();
+               } else if (k % 5 = 0) {
+                   call Buzz();
+               } else {
+                   PrintNum(k);
+               };
+
+        ret: return;
+    }
+
+    {
+        l1: while (n < N) {
+            inc: n := n + 1;
+            call RunFizzBuzz(n, 3, 5);
+        }
+    }
+}
+ ***************************************************************************)
+\* BEGIN TRANSLATION
+\* Label p of procedure Fizz at line 16 col 12 changed to p_
+\* Label p of procedure Buzz at line 21 col 12 changed to p_B
+CONSTANT defaultInitValue
+VARIABLES n, pc, stack, k, n1, n2
+
+vars == << n, pc, stack, k, n1, n2 >>
+
+Init == (* Global variables *)
+        /\ n = 0
+        (* Procedure RunFizzBuzz *)
+        /\ k = defaultInitValue
+        /\ n1 = defaultInitValue
+        /\ n2 = defaultInitValue
+        /\ stack = << >>
+        /\ pc = "l1"
+
+p_ == /\ pc = "p_"
+      /\ PrintT("fizz")
+      /\ pc' = Head(stack).pc
+      /\ stack' = Tail(stack)
+      /\ UNCHANGED << n, k, n1, n2 >>
+
+Fizz == p_
+
+p_B == /\ pc = "p_B"
+       /\ PrintT("buzz")
+       /\ pc' = Head(stack).pc
+       /\ stack' = Tail(stack)
+       /\ UNCHANGED << n, k, n1, n2 >>
+
+Buzz == p_B
+
+p == /\ pc = "p"
+     /\ PrintT("fizzbuzz")
+     /\ pc' = Head(stack).pc
+     /\ stack' = Tail(stack)
+     /\ UNCHANGED << n, k, n1, n2 >>
+
+FizzBuzz == p
+
+check == /\ pc = "check"
+         /\ IF (k % n1 = 0) /\ (k % n2 = 0)
+               THEN /\ stack' = << [ procedure |->  "FizzBuzz",
+                                     pc        |->  "ret" ] >>
+                                 \o stack
+                    /\ pc' = "p"
+               ELSE /\ IF k % 3 = 0
+                          THEN /\ stack' = << [ procedure |->  "Fizz",
+                                                pc        |->  "ret" ] >>
+                                            \o stack
+                               /\ pc' = "p_"
+                          ELSE /\ IF k % 5 = 0
+                                     THEN /\ stack' = << [ procedure |->  "Buzz",
+                                                           pc        |->  "ret" ] >>
+                                                       \o stack
+                                          /\ pc' = "p_B"
+                                     ELSE /\ PrintT(k)
+                                          /\ pc' = "ret"
+                                          /\ stack' = stack
+         /\ UNCHANGED << n, k, n1, n2 >>
+
+ret == /\ pc = "ret"
+       /\ pc' = Head(stack).pc
+       /\ k' = Head(stack).k
+       /\ n1' = Head(stack).n1
+       /\ n2' = Head(stack).n2
+       /\ stack' = Tail(stack)
+       /\ n' = n
+
+RunFizzBuzz == check \/ ret
+
+l1 == /\ pc = "l1"
+      /\ IF n < N
+            THEN /\ pc' = "inc"
+            ELSE /\ pc' = "Done"
+      /\ UNCHANGED << n, stack, k, n1, n2 >>
+
+inc == /\ pc = "inc"
+       /\ n' = n + 1
+       /\ /\ k' = n'
+          /\ n1' = 3
+          /\ n2' = 5
+          /\ stack' = << [ procedure |->  "RunFizzBuzz",
+                           pc        |->  "l1",
+                           k         |->  k,
+                           n1        |->  n1,
+                           n2        |->  n2 ] >>
+                       \o stack
+       /\ pc' = "check"
+
+Next == Fizz \/ Buzz \/ FizzBuzz \/ RunFizzBuzz \/ l1 \/ inc
+           \/ (* Disjunct to prevent deadlock on termination *)
+              (pc = "Done" /\ UNCHANGED vars)
+
+Spec == Init /\ [][Next]_vars
+
+Termination == <>(pc = "Done")
+
+\* END TRANSLATION
+=============================================================================

--- a/test/pgo/TestCodeGenRunTest.java
+++ b/test/pgo/TestCodeGenRunTest.java
@@ -51,6 +51,17 @@ public class TestCodeGenRunTest {
 					},
 					Arrays.asList("1", "2", "fizz", "4", "buzz", "fizz", "7", "8", "fizz", "buzz",
 							"11", "fizz", "13", "14", "fizzbuzz", "16", "17", "fizz", "19", "buzz"),
+				},
+				{
+						"ProceduresPSyntax.tla",
+						new HashMap<String, String>() {
+							{
+								put("N", "20");
+								put("defaultInitValue", "0");
+							}
+						},
+						Arrays.asList("1", "2", "fizz", "4", "buzz", "fizz", "7", "8", "fizz", "buzz",
+								"11", "fizz", "13", "14", "fizzbuzz", "16", "17", "fizz", "19", "buzz"),
 				}
 		});
 	}

--- a/test/pgo/TestCodeGenRunTest.java
+++ b/test/pgo/TestCodeGenRunTest.java
@@ -62,7 +62,19 @@ public class TestCodeGenRunTest {
 						},
 						Arrays.asList("1", "2", "fizz", "4", "buzz", "fizz", "7", "8", "fizz", "buzz",
 								"11", "fizz", "13", "14", "fizzbuzz", "16", "17", "fizz", "19", "buzz"),
+				},
+				{
+						"SingleProcess.tla",
+						new HashMap<String, String>() {
+							{
+								put("N", "20");
+								put("defaultInitValue", "0");
+							}
+						},
+						Arrays.asList("1", "2", "fizz", "4", "buzz", "fizz", "7", "8", "fizz", "buzz",
+								"11", "fizz", "13", "14", "fizzbuzz", "16", "17", "fizz", "19", "buzz"),
 				}
+
 		});
 	}
 


### PR DESCRIPTION
This updates the grammar for P-syntax PlusCal specs, which had the same issue of not recognizing procedures and macros taking no parameters.

I also added an integration test for single-process specs.