### PR TITLE
Cosmetic changes

### DIFF
--- a/src/pgo/PGoNetOptions.java
+++ b/src/pgo/PGoNetOptions.java
@@ -33,7 +33,7 @@ public class PGoNetOptions {
 		public static final String STATE_ETCD = "etcd";
 		public static final String STATE_SERVER = "state-server";
 
-		private static final String DEFAULT_STATE_STRATEGY = STATE_ETCD;
+		private static final String DEFAULT_STATE_STRATEGY = STATE_SERVER;
 		private static final int DEFAULT_TIMEOUT = 3;
 
 		public String strategy;

--- a/src/pgo/PGoOptions.java
+++ b/src/pgo/PGoOptions.java
@@ -25,9 +25,6 @@ public class PGoOptions {
 	@Option(value = "-c path to the configuration file, if any")
 	public String configFilePath = "";
 
-	@Option(value = "write the AST generated and skip the rest", aliases = { "-ast" })
-	public boolean writeAST = false;
-
 	public String inputFilePath;
 
 	// fields extracted from the JSON configuration file

--- a/src/pgo/PGoOptions.java
+++ b/src/pgo/PGoOptions.java
@@ -46,7 +46,7 @@ public class PGoOptions {
 	}
 
 	public void parse() throws PGoOptionException {
-		if (help) {
+		if (help || remainingArgs.length != 1) {
 			printHelp();
 			System.exit(0);
 		}

--- a/test/pgo/PGoNetOptionsTest.java
+++ b/test/pgo/PGoNetOptionsTest.java
@@ -51,7 +51,7 @@ public class PGoNetOptionsTest {
 	@Test
 	public void testDefaultStateStrategy() throws PGoOptionException {
 		getNetworking().getJSONObject(PGoNetOptions.STATE_FIELD).remove("strategy");
-		assertEquals(PGoNetOptions.StateOptions.STATE_ETCD, options().getStateOptions().strategy);
+		assertEquals(PGoNetOptions.StateOptions.STATE_SERVER, options().getStateOptions().strategy);
 	}
 
 	// having no endpoints in the centralized-etcd strategy is invalid


### PR DESCRIPTION
Small fixes while I was reading the updated manual:

* remove unused code related to the now removed `writeAST` option;
* use `state-server` as the default distributed state strategy
* we were getting an exception if we invoked the `./pgo.sh` script without any arguments. We now print the help message.