### PR TITLE
Run test suite on Java versions 8 and 9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+jdk:
+    - openjdk8
+    - openjdk9
 script:
   - eval "$(gimme 1.10)" && go version
   - eval "$(gimme 1.10)" && ant tests


### PR DESCRIPTION
Found no issues on my machine. This updates our Travis configuration to run the test suite on both versions, since it wouldn't hurt to remain compatible.