### PR TITLE
Add compilation flag to indicate MPCal -> PCal compilation

### DIFF
--- a/examples/mpcal/dqueue.tla
+++ b/examples/mpcal/dqueue.tla
@@ -1,0 +1,178 @@
+----------------------------- MODULE dqueue_mpcal -----------------------------
+(***************************************************************************)
+(* Distributed queue using Modular PlusCal.                                *)
+(***************************************************************************)
+
+EXTENDS Naturals, Sequences, FiniteSets, TLC
+CONSTANT BUFFER_SIZE
+
+(***************************************************************************
+--mpcal DistQueue {
+  mapping macro LossyNetwork {      
+      read {
+          await Len($variable) > 0;
+          with (msg = Head($variable)) {
+              $variable := Tail($variable);
+              yield msg;
+          };
+      }
+      
+      write {
+          either {
+              yield $variable
+          } or {
+              await Len($variable) < BUFFER_SIZE;
+              yield Append($variable, $value);
+          }
+      }
+  }
+  
+  mapping macro CyclicReads {
+      read  {
+          $variable := ($variable + 1) % BUFFER_SIZE;
+          yield $variable;
+       
+      }
+      
+      write { yield $variable };
+  }
+    
+  (* consumer: Processes one element read from the network at a time, infinitely *)
+  archetype AConsumer(network, ref processor) {
+      c: while (TRUE) {
+          (* behavior of reading from network is implementation specific *)
+          (* behavior of writing to "processor" is implementation specific *)
+          c1: processor := network
+      }
+  }
+  
+  archetype AProducer(ref network, stream) {
+      p: while (TRUE) {
+          p1: network := stream;
+      }
+  }
+  
+  variables network = <<>>,
+            processor = 0,
+            stream = 0;
+            
+  fair process (Consumer \in {0,1}) == instance AConsumer(network, ref processor)
+      mapping network via LossyNetwork;
+  fair process (Producer = 2) == instance AProducer(ref network, ref stream)
+      mapping network via LossyNetwork
+      mapping stream via CyclicReads;
+}
+***************************************************************************)
+
+
+(***************************************************************************
+--algorithm DistQueue {
+    variables network = <<>>,
+              processor = 0,
+              stream = 1;
+              
+    fair process (Consumer \in {0,1})
+    variables tmp0;
+    {
+        c: while (TRUE) {
+            c1: await Len(network) > 0;
+                with (msg = Head(network)) {
+                    network := Tail(network);
+                    tmp0 := msg;
+                };
+                processor := tmp0;
+        }
+    }
+    
+    fair process (Producer = 2)
+    variables tmp0, tmp1;
+    {
+        p: while(TRUE) {
+           p1: either {
+                   tmp0 := network
+               } or {
+                   stream := (stream + 1) % BUFFER_SIZE;
+                   tmp1 := stream;
+                   await Len(network) < BUFFER_SIZE;
+                   tmp0 := Append(network, tmp1);
+               };
+               network := tmp0;
+        }
+    }
+
+}
+***************************************************************************)
+\* BEGIN TRANSLATION
+\* Process variable tmp0 of process Consumer at line 74 col 15 changed to tmp0_
+CONSTANT defaultInitValue
+VARIABLES network, processor, stream, pc, tmp0_, tmp0, tmp1
+
+vars == << network, processor, stream, pc, tmp0_, tmp0, tmp1 >>
+
+ProcSet == ({0,1}) \cup {2}
+
+Init == (* Global variables *)
+        /\ network = <<>>
+        /\ processor = 0
+        /\ stream = 1
+        (* Process Consumer *)
+        /\ tmp0_ = [self \in {0,1} |-> defaultInitValue]
+        (* Process Producer *)
+        /\ tmp0 = defaultInitValue
+        /\ tmp1 = defaultInitValue
+        /\ pc = [self \in ProcSet |-> CASE self \in {0,1} -> "c"
+                                        [] self = 2 -> "p"]
+
+c(self) == /\ pc[self] = "c"
+           /\ pc' = [pc EXCEPT ![self] = "c1"]
+           /\ UNCHANGED << network, processor, stream, tmp0_, tmp0, tmp1 >>
+
+c1(self) == /\ pc[self] = "c1"
+            /\ Len(network) > 0
+            /\ LET msg == Head(network) IN
+                 /\ network' = Tail(network)
+                 /\ tmp0_' = [tmp0_ EXCEPT ![self] = msg]
+            /\ processor' = tmp0_'[self]
+            /\ pc' = [pc EXCEPT ![self] = "c"]
+            /\ UNCHANGED << stream, tmp0, tmp1 >>
+
+Consumer(self) == c(self) \/ c1(self)
+
+p == /\ pc[2] = "p"
+     /\ pc' = [pc EXCEPT ![2] = "p1"]
+     /\ UNCHANGED << network, processor, stream, tmp0_, tmp0, tmp1 >>
+
+p1 == /\ pc[2] = "p1"
+      /\ \/ /\ tmp0' = network
+            /\ UNCHANGED <<stream, tmp1>>
+         \/ /\ stream' = (stream + 1) % BUFFER_SIZE
+            /\ tmp1' = stream'
+            /\ Len(network) < BUFFER_SIZE
+            /\ tmp0' = Append(network, tmp1')
+      /\ network' = tmp0'
+      /\ pc' = [pc EXCEPT ![2] = "p"]
+      /\ UNCHANGED << processor, tmp0_ >>
+
+Producer == p \/ p1
+
+Next == Producer
+           \/ (\E self \in {0,1}: Consumer(self))
+
+Spec == /\ Init /\ [][Next]_vars
+        /\ \A self \in {0,1} : WF_vars(Consumer(self))
+        /\ WF_vars(Producer)
+
+\* END TRANSLATION
+
+\* Basic invariant
+ProducerConsumer == stream - processor <= BUFFER_SIZE+1
+
+\* Messages produced are eventually consumed
+\* Not satisfied because message loss is not accounted for
+EventuallyConsumed == \A n \in 0..BUFFER_SIZE : (stream = n) => <>(processor = n)
+
+=============================================================================
+\* Modification History
+\* Last modified Fri Sep 28 16:49:58 PDT 2018 by rmc
+\* Last modified Wed Oct 12 02:41:48 PDT 2011 by lamport
+\* Created Mon Oct 10 06:26:47 PDT 2011 by lamport

--- a/src/pgo/PGoMain.java
+++ b/src/pgo/PGoMain.java
@@ -73,24 +73,29 @@ public class PGoMain {
 
 			logger.info("Opening source file");
 			Path inputFilePath = Paths.get(opts.inputFilePath);
-			final boolean fromModularPlusCal;
+			final boolean isMPCal;
 			final ModularPlusCalBlock modularPlusCalBlock;
 			final TLAModule tlaModule;
+
 			try (FileChannel fileChannel = new RandomAccessFile(inputFilePath.toFile(), "r").getChannel()) {
 				MappedByteBuffer buffer = fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, fileChannel.size());
 				// assume UTF-8, though technically TLA+ is ASCII only according to the book
 				CharBuffer inputFileContents = StandardCharsets.UTF_8.decode(buffer);
 
-				if (ModularPlusCalParsingPass.hasModularPlusCalBlock(inputFilePath, inputFileContents)) {
-					logger.info("Parse modular PlusCal code");
+				isMPCal = ModularPlusCalParsingPass.hasModularPlusCalBlock(inputFilePath, inputFileContents);
+				if (opts.mpcalCompile && !isMPCal) {
+					ctx.error(new OptionParserIssue("Specification does not contain a Modular PlusCal block."));
+					checkErrors(ctx);
+				}
+
+				if (isMPCal) {
+					logger.info("Parsing modular PlusCal code");
 					modularPlusCalBlock = ModularPlusCalParsingPass.perform(ctx, inputFilePath, inputFileContents);
-					fromModularPlusCal = true;
 					checkErrors(ctx);
 				} else {
 					logger.info("Parsing PlusCal code");
 					final PlusCalAlgorithm plusCalAlgorithm = PlusCalParsingPass.perform(
 							ctx, inputFilePath, inputFileContents);
-					fromModularPlusCal = false;
 					checkErrors(ctx);
 					modularPlusCalBlock = ModularPlusCalBlock.from(plusCalAlgorithm);
 				}
@@ -115,17 +120,21 @@ public class PGoMain {
 			TLAScopeBuilder tlaScope = TLAScopingPass.perform(ctx, registry, loader, constantDefinitions, tlaModule);
 			checkErrors(ctx);
 
-			logger.info("Resolve modular PlusCal scoping");
+			logger.info("Resolve Modular PlusCal scoping");
 			TLAScopeBuilder modularPlusCalScope = ModularPlusCalScopingPass.perform(
 					ctx, registry, loader, tlaScope, modularPlusCalBlock);
 			checkErrors(ctx);
 
-			logger.info("Expanding PlusCal macros and modular PlusCal instances");
+			String msg = "Expanding PlusCal macros";
+			if (isMPCal) {
+				msg += " and Modular PlusCal instances";
+			}
+			logger.info(msg);
 			ModularPlusCalBlock expandedModularPlusCalBlock = ModularPlusCalExpansionPass.perform(
 					ctx, modularPlusCalBlock);
 			checkErrors(ctx);
 
-			logger.info("Resolving PlusCal and modular PlusCal scoping");
+			logger.info("Resolving PlusCal scoping");
 			PlusCalScopingPass.perform(
 					ctx, registry, loader, tlaScope, modularPlusCalScope, expandedModularPlusCalBlock);
 			checkErrors(ctx);
@@ -137,31 +146,41 @@ public class PGoMain {
 			logger.info("Inferring atomicity requirements");
 			AtomicityInferencePass.perform(registry, expandedModularPlusCalBlock);
 
-			logger.info("Initial code generation");
-			GoModule goModule = CodeGenPass.perform(registry, typeMap, opts, expandedModularPlusCalBlock);
+			if (opts.mpcalCompile) {
+				// compilation of MPCal -> PCal
+				throw new UnsupportedOperationException("Generation of PCal specs from MPCal currently unsupported");
 
-			logger.info("Normalising generated code");
-			GoModule normalisedGoModule = CodeNormalisingPass.perform(goModule);
+			} else if (isMPCal) {
+				// compilation of MPCal -> Go
+				throw new UnsupportedOperationException("Compilation of MPCal specs currently unsupported");
 
-			logger.info("Writing Go module to \"" + opts.buildFile + "\" in folder \"" + opts.buildDir + "\"");
-			try(
-					BufferedWriter writer = Files.newBufferedWriter(Paths.get(opts.buildDir+"/"+opts.buildFile));
-					IndentingWriter out = new IndentingWriter(writer)
-			) {
-				normalisedGoModule.accept(new GoNodeFormattingVisitor(out));
+			} else {
+				// compilation of PCal -> Go
+				logger.info("Initial code generation");
+				GoModule goModule = CodeGenPass.perform(registry, typeMap, opts, expandedModularPlusCalBlock);
+
+				logger.info("Normalising generated code");
+				GoModule normalisedGoModule = CodeNormalisingPass.perform(goModule);
+
+				logger.info("Writing Go module to \"" + opts.buildFile + "\" in folder \"" + opts.buildDir + "\"");
+				try(
+						BufferedWriter writer = Files.newBufferedWriter(Paths.get(opts.buildDir+"/"+opts.buildFile));
+						IndentingWriter out = new IndentingWriter(writer)
+				) {
+					normalisedGoModule.accept(new GoNodeFormattingVisitor(out));
+				}
+
+				logger.info("Copying necessary Go packages to folder \"" + opts.buildDir + "\"");
+				copyPackages(opts.buildDir);
+
+				logger.info("Formatting generated Go code");
+				try {
+					goFmt(opts.buildDir + "/" + opts.buildFile);
+				} catch (Exception e) {
+					logger.warning(String.format("Failed to format Go code. Error: %s", e.getMessage()));
+				}
+				return true;
 			}
-
-			logger.info("Copying necessary Go packages to folder \"" + opts.buildDir + "\"");
-			copyPackages(opts.buildDir);
-
-			logger.info("Formatting generated Go code");
-			try {
-				goFmt(opts.buildDir + "/" + opts.buildFile);
-			} catch (Exception e) {
-				logger.warning(String.format("Failed to format Go code. Error: %s", e.getMessage()));
-			}
-			return true;
-
 		} catch (PGoTransException | IOException e) {
 			logger.severe(e.getMessage());
 			e.printStackTrace();

--- a/src/pgo/PGoMain.java
+++ b/src/pgo/PGoMain.java
@@ -18,6 +18,7 @@ import pgo.trans.passes.codegen.CodeGenPass;
 import pgo.trans.passes.constdef.ConstantDefinitionParsingPass;
 import pgo.trans.passes.expansion.ModularPlusCalExpansionPass;
 import pgo.trans.passes.mpcal.ModularPlusCalParsingPass;
+import pgo.trans.passes.mpcal.ModularPlusCalValidationPass;
 import pgo.trans.passes.scope.pluscal.PlusCalScopingPass;
 import pgo.trans.passes.scope.tla.TLAScopingPass;
 import pgo.trans.passes.scope.mpcal.ModularPlusCalScopingPass;
@@ -123,6 +124,10 @@ public class PGoMain {
 			logger.info("Resolve Modular PlusCal scoping");
 			TLAScopeBuilder modularPlusCalScope = ModularPlusCalScopingPass.perform(
 					ctx, registry, loader, tlaScope, modularPlusCalBlock);
+			checkErrors(ctx);
+
+			logger.info("Validating " + (isMPCal ? "Modular PlusCal" : "PlusCal") +  " semantics");
+			ModularPlusCalValidationPass.perform(ctx, modularPlusCalBlock);
 			checkErrors(ctx);
 
 			String msg = "Expanding PlusCal macros";

--- a/test/pgo/IntegrationTestingUtils.java
+++ b/test/pgo/IntegrationTestingUtils.java
@@ -95,7 +95,7 @@ public class IntegrationTestingUtils {
 					out.write("{");
 					out.newLine();
 					try (IndentingWriter.Indent i2_ = out.indent()) {
-						out.write("print ");
+						out.write("l: print ");
 						result.accept(new TLAExpressionFormattingVisitor(out));
 					}
 					out.newLine();

--- a/test/pgo/trans/intermediate/ModularPlusCalLabelingRulesTest.java
+++ b/test/pgo/trans/intermediate/ModularPlusCalLabelingRulesTest.java
@@ -29,10 +29,16 @@ public class ModularPlusCalLabelingRulesTest {
                 // --mpcal NoIssues {
                 //     archetype MyArchetype() {
                 //         l1: print(1 + 1);
+                //         l2: either { x := 10 } or { x := 20 };
                 //     }
                 //
                 //     procedure MyProcedure() {
                 //         l2: print(3 - 3);
+                //             if (TRUE) {
+                //                 y := 20;
+                //             } else {
+                //                 y := 10;
+                //             }
                 //     }
                 //
                 //     process (MyProcess = 32) {
@@ -47,9 +53,25 @@ public class ModularPlusCalLabelingRulesTest {
                                     "MyArchetype",
                                     Collections.emptyList(),
                                     Collections.emptyList(),
-                                    Collections.singletonList(
-                                            labeled(label("l1"), printS(binop("+", num(1), num(1))))
-                                    )
+                                    new ArrayList<PlusCalStatement>() {{
+                                        add(labeled(
+                                                label("l1"),
+                                                printS(binop("+", num(1), num(1))))
+                                        );
+
+                                        add(labeled(
+                                                label("l2"),
+                                                either(new ArrayList<List<PlusCalStatement>>() {{
+                                                    add(Collections.singletonList(
+                                                            assign(idexp("x"), num(10))
+                                                    ));
+
+                                                    add(Collections.singletonList(
+                                                            assign(idexp("x"), num(20))
+                                                    ));
+                                                }})
+                                        ));
+                                    }}
                             )
                         ),
                         Collections.emptyList(),
@@ -61,7 +83,19 @@ public class ModularPlusCalLabelingRulesTest {
                                         "MyProcedure",
                                         Collections.emptyList(),
                                         Collections.emptyList(),
-                                        labeled(label("l2"), printS(binop("-", num(3), num(3))))
+                                        labeled(
+                                                label("l2"),
+                                                printS(binop("-", num(3), num(3))),
+                                                ifS(
+                                                        bool(true),
+                                                        Collections.singletonList(
+                                                                assign(idexp("y"), num(10))
+                                                        ),
+                                                        Collections.singletonList(
+                                                                assign(idexp("y"), num(20))
+                                                        )
+                                                )
+                                        )
                                 )
                         ),
                         Collections.emptyList(),


### PR DESCRIPTION
Now if you invoke PGo with `-m`, it will attempt to compile an MPCal spec to PlusCal (instead of the traditional spec -> Go compilation pipeline).

I also added an example MPCal spec (a version of `dqueue` in Modular PlusCal) and integrated the validation pass introduced in #94.