### PR TITLE
Do not allow Modular PlusCal syntax in PlusCal specs

### DIFF
--- a/examples/mpcal/dqueue.tla
+++ b/examples/mpcal/dqueue.tla
@@ -34,7 +34,7 @@ CONSTANT BUFFER_SIZE
        
       }
       
-      write { yield $variable };
+      write { yield $variable }
   }
     
   (* consumer: Processes one element read from the network at a time, infinitely *)

--- a/src/pgo/PGoMain.java
+++ b/src/pgo/PGoMain.java
@@ -37,6 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -106,14 +107,19 @@ public class PGoMain {
 				checkErrors(ctx);
 			}
 
-			logger.info("Parsing constant definitions from configuration");
-			Map<String, TLAExpression> constantDefinitions = ConstantDefinitionParsingPass.perform(
-					ctx, opts.constants.getConstants());
-			checkErrors(ctx);
+			Map<String, TLAExpression> constantDefinitions = new HashMap<>();
 
-			logger.info("Checking compile options for sanity");
-			CheckOptionsPass.perform(ctx, modularPlusCalBlock, opts);
-			checkErrors(ctx);
+			// check compilation options if we are compiling to an implementation
+			if (!opts.mpcalCompile) {
+				logger.info("Parsing constant definitions from configuration");
+				constantDefinitions = ConstantDefinitionParsingPass.perform(
+						ctx, opts.constants.getConstants());
+				checkErrors(ctx);
+
+				logger.info("Checking compile options for sanity");
+				CheckOptionsPass.perform(ctx, modularPlusCalBlock, opts);
+				checkErrors(ctx);
+			}
 
 			logger.info("Resolving TLA+ scoping");
 			TLAModuleLoader loader = new TLAModuleLoader(Collections.singletonList(inputFilePath.getParent()));

--- a/src/pgo/model/mpcal/ModularPlusCalBuilder.java
+++ b/src/pgo/model/mpcal/ModularPlusCalBuilder.java
@@ -24,9 +24,9 @@ public class ModularPlusCalBuilder {
 				target);
 	}
 
-	public static ModularPlusCalInstance instance(PlusCalVariableDeclaration name, String target,
-	                                              List<TLAExpression> params, List<ModularPlusCalMapping> mappings) {
-		return new ModularPlusCalInstance(SourceLocation.unknown(), name, target, params, mappings);
+	public static ModularPlusCalInstance instance(PlusCalVariableDeclaration name, PlusCalFairness fairness,
+												  String target, List<TLAExpression> params, List<ModularPlusCalMapping> mappings) {
+		return new ModularPlusCalInstance(SourceLocation.unknown(), name, fairness, target, params, mappings);
 	}
 
 	public static ModularPlusCalMappingMacro mappingMacro(String name, List<PlusCalStatement> readBody,

--- a/src/pgo/model/mpcal/ModularPlusCalInstance.java
+++ b/src/pgo/model/mpcal/ModularPlusCalInstance.java
@@ -1,5 +1,6 @@
 package pgo.model.mpcal;
 
+import pgo.model.pcal.PlusCalFairness;
 import pgo.model.pcal.PlusCalVariableDeclaration;
 import pgo.model.tla.TLAExpression;
 import pgo.util.SourceLocation;
@@ -18,16 +19,18 @@ import java.util.stream.Collectors;
  */
 public class ModularPlusCalInstance extends ModularPlusCalUnit {
 	private final PlusCalVariableDeclaration name;
+	private final PlusCalFairness fairness;
 	private final String target;
 	private final List<TLAExpression> params;
 	private final List<ModularPlusCalMapping> mappings;
 	// TODO
 	// private final Located<String> interleavingTarget;
 
-	public ModularPlusCalInstance(SourceLocation location, PlusCalVariableDeclaration name, String target,
-	                              List<TLAExpression> params, List<ModularPlusCalMapping> mappings) {
+	public ModularPlusCalInstance(SourceLocation location, PlusCalVariableDeclaration name, PlusCalFairness fairness,
+								  String target, List<TLAExpression> params, List<ModularPlusCalMapping> mappings) {
 		super(location);
 		this.name = name;
+		this.fairness = fairness;
 		this.target = target;
 		this.params = params;
 		this.mappings = mappings;
@@ -38,6 +41,7 @@ public class ModularPlusCalInstance extends ModularPlusCalUnit {
 		return new ModularPlusCalInstance(
 				getLocation(),
 				name.copy(),
+				fairness,
 				target,
 				params.stream().map(TLAExpression::copy).collect(Collectors.toList()),
 				mappings.stream().map(ModularPlusCalMapping::copy).collect(Collectors.toList()));
@@ -59,6 +63,7 @@ public class ModularPlusCalInstance extends ModularPlusCalUnit {
 		ModularPlusCalInstance that = (ModularPlusCalInstance) obj;
 		return target.equals(that.target) &&
 				name.equals(that.name) &&
+				fairness.equals(that.fairness) &&
 				Objects.equals(params, that.params) &&
 				Objects.equals(mappings, that.mappings);
 	}
@@ -70,6 +75,10 @@ public class ModularPlusCalInstance extends ModularPlusCalUnit {
 
 	public PlusCalVariableDeclaration getName() {
 		return name;
+	}
+
+	public PlusCalFairness getFairness() {
+		return this.fairness;
 	}
 
 	public String getTarget() {

--- a/src/pgo/model/mpcal/ModularPlusCalNodeFormattingVisitor.java
+++ b/src/pgo/model/mpcal/ModularPlusCalNodeFormattingVisitor.java
@@ -2,6 +2,8 @@ package pgo.model.mpcal;
 
 import pgo.TODO;
 import pgo.formatters.IndentingWriter;
+import pgo.formatters.PlusCalNodeFormattingVisitor;
+import pgo.model.pcal.PlusCalStatement;
 
 import java.io.IOException;
 import java.util.stream.Collectors;
@@ -54,6 +56,23 @@ public class ModularPlusCalNodeFormattingVisitor extends ModularPlusCalNodeVisit
 
 	@Override
 	public Void visit(ModularPlusCalMappingMacro modularPlusCalMappingMacro) throws IOException {
-		throw new TODO();
+		out.write("mapping macro ");
+		out.write(modularPlusCalMappingMacro.getName());
+		out.write("{");
+
+		out.write("read {");
+		for (PlusCalStatement s : modularPlusCalMappingMacro.getReadBody()) {
+			s.accept(new PlusCalNodeFormattingVisitor(out));
+		}
+		out.write("}");
+
+		out.write("write {");
+		for (PlusCalStatement s : modularPlusCalMappingMacro.getWriteBody()) {
+			s.accept(new PlusCalNodeFormattingVisitor(out));
+		}
+		out.write("}");
+
+		out.write("}");
+		return null;
 	}
 }

--- a/src/pgo/model/tla/TLAOperatorCall.java
+++ b/src/pgo/model/tla/TLAOperatorCall.java
@@ -3,6 +3,7 @@ package pgo.model.tla;
 import pgo.util.SourceLocation;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -68,19 +69,9 @@ public class TLAOperatorCall extends TLAExpression {
 		if (getClass() != obj.getClass())
 			return false;
 		TLAOperatorCall other = (TLAOperatorCall) obj;
-		if (args == null) {
-			if (other.args != null)
-				return false;
-		} else if (!args.equals(other.args))
-			return false;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
-			return false;
-		if (prefix == null) {
-			return other.prefix == null;
-		} else return prefix.equals(other.prefix);
+        return this.getName().equals(other.getName()) &&
+				Objects.equals(this.getArgs(), other.getArgs()) &&
+				Objects.equals(this.getPrefix(), other.getPrefix());
 	}
 
 }

--- a/src/pgo/parser/ModularPlusCalParser.java
+++ b/src/pgo/parser/ModularPlusCalParser.java
@@ -1,10 +1,7 @@
 package pgo.parser;
 
 import pgo.model.mpcal.*;
-import pgo.model.pcal.PlusCalMultiProcess;
-import pgo.model.pcal.PlusCalSingleProcess;
-import pgo.model.pcal.PlusCalStatement;
-import pgo.model.pcal.PlusCalVariableDeclaration;
+import pgo.model.pcal.*;
 import pgo.model.tla.*;
 
 import java.util.Collections;
@@ -78,11 +75,19 @@ public class ModularPlusCalParser {
 					seq.getValue().getFirst().getValue()));
 
 	private static final Grammar<ModularPlusCalInstance> C_SYNTAX_INSTANCE = emptySequence()
+			.part(parseOneOf(
+					emptySequence()
+							.drop(parsePlusCalToken("fair"))
+							.drop(parsePlusCalToken("+"))
+							.map(seq -> new Located<>(seq.getLocation(), PlusCalFairness.STRONG_FAIR)),
+					parsePlusCalToken("fair").map(s -> new Located<>(s.getLocation(), PlusCalFairness.WEAK_FAIR)),
+					nop().map(v -> new Located<>(v.getLocation(), PlusCalFairness.UNFAIR))
+			))
 			.drop(parsePlusCalToken("process"))
 			.drop(parsePlusCalToken("("))
 			.part(VARIABLE_DECLARATION)
 			.drop(parsePlusCalToken(")"))
-			.drop(parsePlusCalToken("="))
+			.drop(parsePlusCalToken("=="))
 			.drop(parsePlusCalToken("instance"))
 			.part(IDENTIFIER)
 			.drop(parsePlusCalToken("("))
@@ -98,6 +103,7 @@ public class ModularPlusCalParser {
 			.map(seq -> new ModularPlusCalInstance(
 					seq.getLocation(),
 					seq.getValue().getRest().getRest().getRest().getFirst(),
+					seq.getValue().getRest().getRest().getRest().getRest().getFirst().getValue(),
 					seq.getValue().getRest().getRest().getFirst().getValue(),
 					seq.getValue().getRest().getFirst(),
 					seq.getValue().getFirst()));

--- a/src/pgo/parser/ModularPlusCalParser.java
+++ b/src/pgo/parser/ModularPlusCalParser.java
@@ -3,6 +3,7 @@ package pgo.parser;
 import pgo.model.mpcal.*;
 import pgo.model.pcal.*;
 import pgo.model.tla.*;
+import pgo.util.SourceLocatable;
 
 import java.util.Collections;
 import java.util.regex.Pattern;
@@ -204,8 +205,8 @@ public class ModularPlusCalParser {
 				});
 	}
 
-	private interface ReadSpec {
-		Object perform() throws ParseFailureException;
+	private interface ReadSpec<Result extends SourceLocatable> {
+		Result perform() throws ParseFailureException;
 	}
 
 	// Modular PlusCal behaves a lot like vanilla PlusCal except in a few key areas:
@@ -219,7 +220,7 @@ public class ModularPlusCalParser {
 	// parsing a MPCal specification, and then resets the grammars back to their
 	// original contents (useful during testing, when PlusCal/MPCal can be parsed in
 	// arbitrary orders).
-	private static Object overwriteGrammars(ReadSpec op) throws ParseFailureException {
+	private static <Result extends SourceLocatable> Result overwriteGrammars(ReadSpec<Result> op) throws ParseFailureException {
 		Grammar<PlusCalStatement> oldUnlabeledStatement = C_SYNTAX_UNLABELED_STMT.getReferencedGrammar();
 		Grammar<PlusCalVariableDeclaration> oldPVarDecl = PVAR_DECL.getReferencedGrammar();
 		Grammar<TLAExpression> oldProcedureParam = PROCEDURE_PARAM.getReferencedGrammar();
@@ -294,20 +295,13 @@ public class ModularPlusCalParser {
 	}
 
 	public static ModularPlusCalBlock readBlock(LexicalContext ctx) throws ParseFailureException {
-		Object block = overwriteGrammars(
-				() -> readOrExcept(ctx, MPCAL_BLOCK)
-		);
-
-		return (ModularPlusCalBlock) block;
+		return overwriteGrammars(() -> readOrExcept(ctx, MPCAL_BLOCK));
 	}
 
 	// testing interface
 
 	static ModularPlusCalUnit readUnit(LexicalContext ctx) throws ParseFailureException {
-		Object unit = overwriteGrammars(
-				() -> readOrExcept(ctx, parseOneOf(C_SYNTAX_ARCHETYPE, C_SYNTAX_INSTANCE, C_SYNTAX_MAPPING_MACRO))
-		);
-
-		return (ModularPlusCalUnit) unit;
+		return overwriteGrammars(() ->
+				readOrExcept(ctx, parseOneOf(C_SYNTAX_ARCHETYPE, C_SYNTAX_INSTANCE, C_SYNTAX_MAPPING_MACRO)));
 	}
 }

--- a/src/pgo/parser/ModularPlusCalParser.java
+++ b/src/pgo/parser/ModularPlusCalParser.java
@@ -140,11 +140,6 @@ public class ModularPlusCalParser {
 			.part(IDENTIFIER)
 			.drop(parsePlusCalToken("{"))
 			.part(parseOneOf(
-					VAR_DECLS,
-					nop().map(seq -> new LocatedList<PlusCalVariableDeclaration>(
-							seq.getLocation(),
-							Collections.emptyList()))))
-			.part(parseOneOf(
 					C_SYNTAX_DEFINITIONS,
 					nop().map(seq -> new LocatedList<TLAUnit>(seq.getLocation(), Collections.emptyList()))))
 			.part(parseOneOf(
@@ -159,6 +154,11 @@ public class ModularPlusCalParser {
 							Collections.emptyList()))))
 			.part(repeat(C_SYNTAX_MACRO))
 			.part(repeat(C_SYNTAX_PROCEDURE))
+			.part(parseOneOf(
+					VAR_DECLS,
+					nop().map(seq -> new LocatedList<PlusCalVariableDeclaration>(
+							seq.getLocation(),
+							Collections.emptyList()))))
 			.part(repeat(C_SYNTAX_INSTANCE))
 			.part(parseOneOf(
 					C_SYNTAX_COMPOUND_STMT.map(stmts -> new PlusCalSingleProcess(stmts.getLocation(), stmts)),
@@ -168,12 +168,12 @@ public class ModularPlusCalParser {
 			.map(seq -> new ModularPlusCalBlock(
 					seq.getLocation(),
 					seq.getValue().getRest().getRest().getRest().getRest().getRest().getRest().getRest().getRest().getFirst(),
+					seq.getValue().getRest().getRest().getFirst(),
 					seq.getValue().getRest().getRest().getRest().getRest().getRest().getRest().getRest().getFirst(),
 					seq.getValue().getRest().getRest().getRest().getRest().getRest().getRest().getFirst(),
 					seq.getValue().getRest().getRest().getRest().getRest().getRest().getFirst(),
 					seq.getValue().getRest().getRest().getRest().getRest().getFirst(),
 					seq.getValue().getRest().getRest().getRest().getFirst(),
-					seq.getValue().getRest().getRest().getFirst(),
 					seq.getValue().getRest().getFirst(),
 					seq.getValue().getFirst()));
 

--- a/src/pgo/parser/PlusCalParser.java
+++ b/src/pgo/parser/PlusCalParser.java
@@ -748,4 +748,15 @@ public final class PlusCalParser {
 	public static PlusCalAlgorithm readAlgorithm(LexicalContext ctx) throws ParseFailureException {
 		return readOrExcept(ctx, ALGORITHM);
 	}
+
+	static PlusCalNode readUnit(LexicalContext ctx) throws ParseFailureException {
+		return readOrExcept(ctx, parseOneOf(
+				C_SYNTAX_MACRO,
+				P_SYNTAX_MACRO,
+				C_SYNTAX_PROCEDURE,
+				P_SYNTAX_PROCEDURE,
+				C_SYNTAX_PROCESS,
+				P_SYNTAX_PROCESS
+		));
+	}
 }

--- a/src/pgo/parser/ReferenceGrammar.java
+++ b/src/pgo/parser/ReferenceGrammar.java
@@ -18,11 +18,6 @@ public class ReferenceGrammar<Result extends SourceLocatable> extends Grammar<Re
 		this.referencedGrammar = new Mutator<>();
 	}
 
-	public ReferenceGrammar(Grammar<Result> referencedGrammar) {
-		Objects.requireNonNull(referencedGrammar);
-		this.referencedGrammar = new Mutator<>(referencedGrammar);
-	}
-
 	public void setReferencedGrammar(Grammar<Result> referencedGrammar) {
 		Objects.requireNonNull(referencedGrammar);
 		this.referencedGrammar.setValue(referencedGrammar);

--- a/src/pgo/parser/TLAParser.java
+++ b/src/pgo/parser/TLAParser.java
@@ -1460,12 +1460,12 @@ public final class TLAParser {
 				.map(seq -> seq.getValue().getFirst());
 	}
 
-	public static Grammar<TLAExpression> parseExpression(List<String> prefixOperators, List<String> infixOperators, List<String> postfixOperators) {
+	public static Grammar<TLAExpression> parseExpression(List<String> prefixOperators, List<String> infixOperators, List<String> postfixOperators, ReferenceGrammar<TLAExpression> expressionNoOperators) {
 		Map<Integer, ReferenceGrammar<TLAExpression>> operatorsByPrecedence = new HashMap<>(18);
 		for(int precedence = 1; precedence < 18; ++precedence) {
 			operatorsByPrecedence.put(precedence, new ReferenceGrammar<>());
 		}
-		operatorsByPrecedence.put(18, EXPRESSION_NO_OPERATORS);
+		operatorsByPrecedence.put(18, expressionNoOperators);
 		for(int precedence = 1; precedence < 18; ++precedence) {
 			operatorsByPrecedence.get(precedence).setReferencedGrammar(parseExpressionFromPrecedence(
 					precedence, operatorsByPrecedence, prefixOperators,
@@ -1475,15 +1475,12 @@ public final class TLAParser {
 	}
 
 	static {
-		EXPRESSION.setReferencedGrammar(parseExpression(PREFIX_OPERATORS, INFIX_OPERATORS, POSTFIX_OPERATORS));
+		EXPRESSION.setReferencedGrammar(parseExpression(PREFIX_OPERATORS, INFIX_OPERATORS, POSTFIX_OPERATORS, EXPRESSION_NO_OPERATORS));
 	}
 
 	static {
 		EXPRESSION_NO_OPERATORS.setReferencedGrammar(
 				parseOneOf(
-						parseTLAToken("$variable").map(seq -> new TLASpecialVariableVariable(seq.getLocation())),
-						parseTLAToken("$value").map(seq -> new TLASpecialVariableValue(seq.getLocation())),
-
 						parseTLANumber(),
 						parseTLAString(),
 						parseTLATokenOneOf(

--- a/test/pgo/parser/ModularPlusCalParserTest.java
+++ b/test/pgo/parser/ModularPlusCalParserTest.java
@@ -42,13 +42,13 @@ public class ModularPlusCalParserTest {
 				},
 				{"---- MODULE Test ----\n" +
 						"(* --mpcal Test {\n" +
-						"     variables global1 = 1, global2 = 2;\n" +
 						"     macro M(a) {\n" +
 						"       print a;\n" +
 						"     }\n" +
 						"     procedure P(b) {\n" +
 						"       print b;\n" +
 						"     }\n" +
+						"     variables global1 = 1, global2 = 2;\n" +
 						"     {\n" +
 						"       print <<global1, global2>>;\n" +
 						"     }\n" +
@@ -74,13 +74,13 @@ public class ModularPlusCalParserTest {
 				},
 				{"---- MODULE Test ----\n" +
 						"(* --mpcal Test {\n" +
-						"     variables global1 = 1, global2 = 2;\n" +
 						"     macro M(a) {\n" +
 						"       print a;\n" +
 						"     }\n" +
 						"     procedure P(b) {\n" +
 						"       print b;\n" +
 						"     }\n" +
+						"     variables global1 = 1, global2 = 2;\n" +
 						"     process (P \\in 1..3) {\n" +
 						"       print <<global1, global2>>;\n" +
 						"     }\n" +

--- a/test/pgo/parser/ModularPlusCalUnitParserTest.java
+++ b/test/pgo/parser/ModularPlusCalUnitParserTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import pgo.model.mpcal.ModularPlusCalUnit;
+import pgo.model.pcal.PlusCalFairness;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -59,16 +60,29 @@ public class ModularPlusCalUnitParserTest {
 				},
 
 				// simple instance
-				{"process (P \\in 1..3) = instance Archetype();",
+				{"process (P \\in 1..3) == instance Archetype();",
 						instance(pcalVarDecl("P", false, true, binop("..", num(1), num(3))),
-								"Archetype", Collections.emptyList(), Collections.emptyList())
+								PlusCalFairness.UNFAIR, "Archetype", Collections.emptyList(), Collections.emptyList())
+				},
+
+				// weak fairness
+				{"fair process (P \\in 1..3) == instance Archetype();",
+						instance(pcalVarDecl("P", false, true, binop("..", num(1), num(3))),
+								PlusCalFairness.WEAK_FAIR, "Archetype", Collections.emptyList(), Collections.emptyList())
+				},
+
+				// strong fairness
+				{"fair+ process (P \\in 1..3) == instance Archetype();",
+						instance(pcalVarDecl("P", false, true, binop("..", num(1), num(3))),
+								PlusCalFairness.STRONG_FAIR, "Archetype", Collections.emptyList(), Collections.emptyList())
 				},
 
 				// full featured instance
-				{"process (P = \"P\") = instance Archetype(ref global1, ref global2, global3)\n" +
+				{"process (P = \"P\") == instance Archetype(ref global1, ref global2, global3)\n" +
 						"  mapping global1 via MappingMacro1\n" +
 						"  mapping global2 via MappingMacro2;",
 						instance(pcalVarDecl("P", false, false, str("P")),
+								PlusCalFairness.UNFAIR,
 								"Archetype",
 								Arrays.asList(
 										ref("global1"),

--- a/test/pgo/parser/ModularPlusCalUnitParserTest.java
+++ b/test/pgo/parser/ModularPlusCalUnitParserTest.java
@@ -132,6 +132,51 @@ public class ModularPlusCalUnitParserTest {
 										await(idexp("someSpecialCondition")),
 										yield(DOLLAR_VALUE)),
 								Collections.singletonList(yield(DOLLAR_VALUE)))
+				},
+
+				// lossy network model
+				{
+					"mapping macro LossyNetwork {\n" +
+					"		read {\n" +
+					"			await Len($variable) > 0;\n" +
+					"			with (msg = Head($variable)) {\n" +
+					"		    	$variable := Tail($variable);\n" +
+					"		    	yield msg;\n" +
+					"			}\n" +
+					"		}\n\n" +
+					"		write {\n" +
+					"			either {\n" +
+					"				yield $variable;\n" +
+					"			} or {\n" +
+					"				await Len($variable) < BUFFER_SIZE;\n" +
+					"				yield Append($variable, $value);\n" +
+					"			}\n" +
+					"		}\n" +
+					"}\n",
+					mappingMacro(
+							"LossyNetwork",
+							Arrays.asList(
+									await(binop(">", opcall("Len", DOLLAR_VARIABLE), num(0))),
+									with(
+											Collections.singletonList(
+													pcalVarDecl("msg", false, false, opcall("Head", DOLLAR_VARIABLE))
+											),
+											assign(DOLLAR_VARIABLE, opcall("Tail", DOLLAR_VARIABLE)),
+											yield(idexp("msg"))
+									)
+							),
+							Arrays.asList(
+									either(Arrays.asList(
+											Collections.singletonList(
+													yield(DOLLAR_VARIABLE)
+											),
+											Arrays.asList(
+													await(binop("<", opcall("Len", DOLLAR_VARIABLE), idexp("BUFFER_SIZE"))),
+													yield(opcall("Append", DOLLAR_VARIABLE, DOLLAR_VALUE))
+											)
+									))
+							)
+					)
 				}
 		});
 	}

--- a/test/pgo/parser/PlusCalUnitParserTest.java
+++ b/test/pgo/parser/PlusCalUnitParserTest.java
@@ -56,10 +56,24 @@ public class PlusCalUnitParserTest {
                         "}",
                 },
 
-                // ref arguments
+                // ref in procedure definition
                 {
                         "procedure MyProcedure(ref x) {\n" +
                                 "either { x := 10 } or { x := 20 };\n" +
+                        "}",
+                },
+
+                // ref in call in procedure
+                {
+                        "procedure MyProcedure() {\n" +
+                                "call OtherProcedure(ref x);\n" +
+                        "}",
+                },
+
+                // ref in call in process
+                {
+                        "process MyProcess() {\n" +
+                                "call MyProcedure(ref x);\n" +
                         "}",
                 },
         });

--- a/test/pgo/parser/PlusCalUnitParserTest.java
+++ b/test/pgo/parser/PlusCalUnitParserTest.java
@@ -1,0 +1,83 @@
+package pgo.parser;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class PlusCalUnitParserTest {
+    @Parameterized.Parameters
+    public static List<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                // yield in a macro
+                {
+                    "macro MyMacro() {\n" +
+                        "yield x + 1;\n" +
+                    "}",
+                },
+
+                // yield in a procedure
+                {
+                        "procedure MyProcedure() {\n" +
+                                "either { yield 10 } or { yield 20 };\n" +
+                         "}",
+                },
+
+                // yield in a process
+                {
+                        "process MyProcess() {\n" +
+                                "while (TRUE) { yield 10 };\n" +
+                         "}",
+                },
+
+                // special variable in a macro
+                {
+                        "macro MyMacro() {\n" +
+                                "x := $variable + 1;\n" +
+                        "}",
+                },
+
+                // special variable in a procedure
+                {
+                        "procedure MyProcedure() {\n" +
+                                "either { x := $variable } or { x := $variable + 1 };\n" +
+                        "}",
+                },
+
+                // special variable in a process
+                {
+                        "process MyProcess() {\n" +
+                                "while (TRUE) { x := $variable };\n" +
+                        "}",
+                },
+
+                // ref arguments
+                {
+                        "procedure MyProcedure(ref x) {\n" +
+                                "either { x := 10 } or { x := 20 };\n" +
+                        "}",
+                },
+        });
+    }
+
+    private static final Path testFile = Paths.get("TEST");
+
+    private String unit;
+
+    public PlusCalUnitParserTest(String unit) {
+        this.unit = unit;
+    }
+
+    @Test(expected = ParseFailureException.class)
+    public void test() throws ParseFailureException {
+        LexicalContext ctx = new LexicalContext(testFile, String.join(System.lineSeparator(), unit.split("\n")));
+        System.out.println(unit);
+
+        PlusCalParser.readUnit(ctx);
+    }
+}


### PR DESCRIPTION
This removes Modular PlusCal bits from the PlusCal grammar. Unfortunately, composing pieces of the grammar in an "intuitive" way is not easy. The approach taken in this pull request is to transform every piece of grammar that needs to be changed to a `ReferencedGrammar`. Then, `ModularPlusCalParser` overwrites the underlying grammar definition with the changes specific to the additions to the language we introduced.

See the `overwriteGrammars` method for more information.

The result of these changes is that using `yield`, special variables (`$variable`) or `ref` in PlusCal specs results in a parse error, as it should.