### PR TITLE
Proposal: unsupported operators

### DIFF
--- a/src/pgo/trans/intermediate/TLABuiltins.java
+++ b/src/pgo/trans/intermediate/TLABuiltins.java
@@ -525,6 +525,18 @@ public class TLABuiltins {
 					throw new TODO();
 				}));
 
+		BuiltinModule FiniteSets = new BuiltinModule();
+		builtinModules.put("FiniteSets", FiniteSets);
+		FiniteSets.addOperator("Cardinality", new TypelessBuiltinOperator(
+				1,
+				(origin, args, solver, generator) -> {
+					throw new TODO();
+				},
+				(builder, origin, registry, arguments, typeMap) -> {
+					throw new TODO();
+				}
+		));
+
 	}
 
 	public static BuiltinModule getUniversalBuiltIns() {


### PR DESCRIPTION
I'd like to use some operators/modules for which we currently do not have code generation/type system support. One example of which is the `FiniteSets` module and the `Cardinality` operator.

I think it's reasonable to expect that PGo should be able to compile MPCal => PlusCal in specs that make use of these features, but fail to generate a Go implementation if requested because that is currently unsupported.

This is what this pull request is changing. Let me know if you have thoughts.
(This is related to #106)