### PR TITLE
Improved TLA+ parse phase speed via hack

### DIFF
--- a/src/pgo/parser/ModularPlusCalParser.java
+++ b/src/pgo/parser/ModularPlusCalParser.java
@@ -120,7 +120,7 @@ public class ModularPlusCalParser {
 
 	private static final Grammar<ModularPlusCalYield> YIELD = emptySequence()
 			.drop(parsePlusCalToken("yield"))
-			.part(TLA_EXPRESSION)
+			.part(cut(TLA_EXPRESSION))
 			.map(seq -> new ModularPlusCalYield(seq.getLocation(), seq.getValue().getFirst()));
 
 	private static final Grammar<ModularPlusCalMappingMacro> C_SYNTAX_MAPPING_MACRO = emptySequence()
@@ -169,7 +169,7 @@ public class ModularPlusCalParser {
 					nop().map(seq -> new LocatedList<PlusCalVariableDeclaration>(
 							seq.getLocation(),
 							Collections.emptyList()))))
-			.part(repeat(C_SYNTAX_INSTANCE))
+			.part(cut(repeat(C_SYNTAX_INSTANCE)))
 			.part(parseOneOf(
 					C_SYNTAX_COMPOUND_STMT.map(stmts -> new PlusCalSingleProcess(stmts.getLocation(), stmts)),
 					repeatOneOrMore(C_SYNTAX_PROCESS).map(procs -> new PlusCalMultiProcess(procs.getLocation(), procs)),

--- a/test/pgo/formatters/TLANodePrintEquivalenceTest.java
+++ b/test/pgo/formatters/TLANodePrintEquivalenceTest.java
@@ -42,7 +42,9 @@ public class TLANodePrintEquivalenceTest {
 					Collections.emptyList()
 					)
 			},
-			{ module("TEST", ids(id("aaa")),
+			// this is broken by a hack that forces parsing only the units BEFORE the translation. after / during the
+			// translation is not needed in practice. If you want this back, make the TLA+ parser faster.
+			/*{ module("TEST", ids(id("aaa")),
 					Arrays.asList(
 							opdef(false, id("foo"), opdecls(opdecl(id("a")), opdecl(id("b"))),
 									num(1)
@@ -55,7 +57,7 @@ public class TLANodePrintEquivalenceTest {
 							opdef(false, id("b"), opdecls(), num(2))
 							)
 					)
-			},
+			},*/
 		});
 	}
 	


### PR DESCRIPTION
I tried a few things to make the TLA+ parser faster, but the more I try the more it occurs to me that the design itself is slow. There's no obvious exponential backtracking when I trace parser execution, so nothing that can be fixed without a much more sophisticated tweak to parser control flow (which would affect the most complex and bug-prone part of the parser: the expression parser).

As such, for the sake of getting results now I disabled parsing the translated TLA+ code. This nets a significant speedup, since most of the TLA+ PGo had to parse was in there. This broke one test which relied on capturing units during / after the translation, which I commented out with a note as to why.

I hope to return one day with a proper fix for this, which may be an actually fast parser based on my thesis work :)