### PR TITLE
Implement the risk bit optimisation for archetype resource usage

### DIFF
--- a/src/pgo/trans/passes/codegen/go/EtcdGlobalVariableStrategy.java
+++ b/src/pgo/trans/passes/codegen/go/EtcdGlobalVariableStrategy.java
@@ -131,6 +131,11 @@ public class EtcdGlobalVariableStrategy extends GlobalVariableStrategy {
 	}
 
 	@Override
+	public void registerNondeterminism(GoBlockBuilder builder) {
+		// pass
+	}
+
+	@Override
 	public void mainPrelude(GoBlockBuilder builder) {
 		StateServerGlobalVariableStrategy.generateProcessSwitch(
 				typeMap, modularPlusCalBlock, builder, findVariable(processNameUID), findVariable(processArgumentUID));

--- a/src/pgo/trans/passes/codegen/go/GlobalVariableStrategy.java
+++ b/src/pgo/trans/passes/codegen/go/GlobalVariableStrategy.java
@@ -33,6 +33,12 @@ public abstract class GlobalVariableStrategy implements CriticalSection {
 		return variables.get(uid);
 	}
 
+	/**
+	 * 	Called at the beginning of an either, to allow ArchetypeResourceGlobalVariableStrategy to statically disallow
+	 * 	any blocking actions that might interfere with the liveness of trying each execution path one by one: any one
+	 * 	path may not do anything that indefinitely holds up the others.
+ 	 */
+	public abstract void registerNondeterminism(GoBlockBuilder builder);
 
 	public abstract void initPostlude(GoModuleBuilder moduleBuilder, GoBlockBuilder initBuilder);
 

--- a/src/pgo/trans/passes/codegen/go/MultithreadedProcessGlobalVariableStrategy.java
+++ b/src/pgo/trans/passes/codegen/go/MultithreadedProcessGlobalVariableStrategy.java
@@ -62,6 +62,11 @@ public class MultithreadedProcessGlobalVariableStrategy extends GlobalVariableSt
 	}
 
 	@Override
+	public void registerNondeterminism(GoBlockBuilder builder) {
+		// pass
+	}
+
+	@Override
 	public void processPrelude(GoBlockBuilder processBody, PlusCalProcess process, String processName, GoVariableName self,
 							   GoType selfType) {
 		processBody.deferStmt(new GoCall(

--- a/src/pgo/trans/passes/codegen/go/PlusCalStatementCodeGenVisitor.java
+++ b/src/pgo/trans/passes/codegen/go/PlusCalStatementCodeGenVisitor.java
@@ -207,6 +207,7 @@ public class PlusCalStatementCodeGenVisitor extends PlusCalStatementVisitor<Void
 			labels.add(builder.newLabel("case" + Integer.toString(i)));
 		}
 		GoLabelName endEither = builder.newLabel("endEither");
+		globalStrategy.registerNondeterminism(builder);
 		// start codegen
 		for (int i = 0; i < cases.size(); i++) {
 			List<PlusCalStatement> eitherCase = cases.get(i);

--- a/src/pgo/trans/passes/codegen/go/SingleThreadedProcessGlobalVariableStrategy.java
+++ b/src/pgo/trans/passes/codegen/go/SingleThreadedProcessGlobalVariableStrategy.java
@@ -14,6 +14,7 @@ import pgo.scope.UID;
 import java.util.Objects;
 
 public class SingleThreadedProcessGlobalVariableStrategy extends GlobalVariableStrategy {
+
 	@Override
 	public void initPostlude(GoModuleBuilder moduleBuilder, GoBlockBuilder initBuilder) {
 		// nothing to do
@@ -22,6 +23,11 @@ public class SingleThreadedProcessGlobalVariableStrategy extends GlobalVariableS
 	@Override
 	public void processPrelude(GoBlockBuilder processBody, PlusCalProcess process, String processName, GoVariableName self, GoType selfType) {
 		throw new InternalCompilerError();
+	}
+
+	@Override
+	public void registerNondeterminism(GoBlockBuilder builder) {
+		// pass
 	}
 
 	@Override

--- a/src/pgo/trans/passes/codegen/go/StateServerGlobalVariableStrategy.java
+++ b/src/pgo/trans/passes/codegen/go/StateServerGlobalVariableStrategy.java
@@ -104,6 +104,11 @@ public class StateServerGlobalVariableStrategy extends GlobalVariableStrategy {
 	}
 
 	@Override
+	public void registerNondeterminism(GoBlockBuilder builder) {
+		// pass
+	}
+
+	@Override
 	public void initPostlude(GoModuleBuilder moduleBuilder, GoBlockBuilder initBuilder) {
 		GoVariableName processName = moduleBuilder.defineGlobal(processNameUID, "processName", GoBuiltins.String);
 		addVariable(processNameUID, processName);

--- a/src/runtime/pgo/distsys/distsys.go
+++ b/src/runtime/pgo/distsys/distsys.go
@@ -603,7 +603,7 @@ func DefineCustomType(value interface{}) {
 
 // Hash returns a uint64 representation for arbitrary data types.
 func Hash(value interface{}) uint64 {
-	result, err := hashstructure.Hash(value, nil)
+	result, err := hashstructure.Hash(value, hashstructure.FormatV2, nil)
 	if err != nil {
 		panic(fmt.Sprintf("Cannot hash value: %v", value))
 	}

--- a/test/mpcal/go/concurrent_replicated_kv/main.go
+++ b/test/mpcal/go/concurrent_replicated_kv/main.go
@@ -95,7 +95,7 @@ func (g Get) Run() chan bool {
 
 		// Read without Acquire because we know `response` is not
 		// shared
-		response.Read()
+		response.Read(new(bool))
 		done <- true
 	})
 

--- a/test/mpcal/go/replicated_kv/main.go
+++ b/test/mpcal/go/replicated_kv/main.go
@@ -71,7 +71,7 @@ func (g Get) Run() error {
 
 	// Read without Acquire because we know `response` is not
 	// shared
-	val, _ := response.Read()
+	val, _ := response.Read(new(bool))
 	if val == nil {
 		fmt.Printf("-- Get %s: %v\n", g.key, nil)
 	} else {


### PR DESCRIPTION
DO NOT MERGE: needs more testing/eval

Without this PR, all archetype resource operations have to be non-blocking, all the time. This is because without any kind of analysis, it is impossible to prove that a given resource operation is not occurring inside the critical section of a mutex (or mutex-like thing), in which case any further blocking may lead to deadlock via the already-locked mutex.

The _risk bit_ allows resources to communicate whether or not their behaviour is mutex-like, allowing operations following, say, the acquisition of a non mutex-like resource to freely block, should that be advantageous.

A poster use-case is TCP channels, which can only be read once there is something in the buffer. Without blocking, waiting must be done via timeouts and backoffs, which is not ideal. The risk bit allows TCP channel reads to block as one might naturally expect, in the common case where the same critical section does not also hold a lock.