### PR TITLE
Enable Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Setup Go environment
+      uses: actions/setup-go@v2.1.3
+      with:
+        go-version: 1.14
+    - name: Run tests
+      run: sbt test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PGo [![Build Status](https://travis-ci.org/UBC-NSS/pgo.svg?branch=master)](https://travis-ci.org/UBC-NSS/pgo)
+# PGo ![CI Status](https://github.com/UBC-NSS/pgo/actions/workflows/ci.yml/badge.svg?branch=master)
 
 PGo is a source to source compiler to compile
 [PlusCal](http://lamport.azurewebsites.net/tla/pluscal.html)


### PR DESCRIPTION
Our CI is broken right now, and Travis has been phasing out. This commit enables the new shiny, and should work with the new sbt setup.