### PR TITLE
Make PlusCal marker issues a real error, not an assertion

### DIFF
--- a/src/pgo/parser/TLAParser.scala
+++ b/src/pgo/parser/TLAParser.scala
@@ -1,12 +1,9 @@
 package pgo.parser
 
-import pgo.model.{Definition, DefinitionOne, SourceLocatable, SourceLocation, SourceLocationWithUnderlying, Visitable}
+import pgo.model.{Definition, DefinitionOne, SourceLocatable, SourceLocation, SourceLocationWithUnderlying}
 import pgo.model.tla._
-import pgo.util.Description
-import pgo.model.Definition.ScopeIdentifierName
 import pgo.util.Description.DescriptionHelper
 
-import scala.collection.mutable
 import scala.util.parsing.combinator.RegexParsers
 
 

--- a/test/files/general/ExprTests.tla.expectpcal
+++ b/test/files/general/ExprTests.tla.expectpcal
@@ -22,8 +22,6 @@ Test2 == \A <<o0nT5iaxQ0CGr, a1FO5HvdyoLWp, uXXYnplomNiSbQyMwj71XmbnXjoqCn7xaeTF
     }
 }
 
-
-
 \* BEGIN PLUSCAL TRANSLATION
 --algorithm ExprTests {
   
@@ -36,7 +34,6 @@ Test2 == \A <<o0nT5iaxQ0CGr, a1FO5HvdyoLWp, uXXYnplomNiSbQyMwj71XmbnXjoqCn7xaeTF
 }
 
 \* END PLUSCAL TRANSLATION
-
 *)
 
 \* BEGIN TRANSLATION

--- a/test/files/general/dqueue.tla.expectpcal
+++ b/test/files/general/dqueue.tla.expectpcal
@@ -75,8 +75,6 @@ CONSTANTS BUFFER_SIZE, NUM_CONSUMERS, PRODUCER
       mapping stream via CyclicReads;
 }
 
-
-
 \* BEGIN PLUSCAL TRANSLATION
 --algorithm dqueue {
   variables network = [id \in (0) .. ((NUM_NODES) - (1)) |-> <<>>]; processor = 0; stream = 0;
@@ -140,7 +138,6 @@ CONSTANTS BUFFER_SIZE, NUM_CONSUMERS, PRODUCER
 }
 
 \* END PLUSCAL TRANSLATION
-
 *)
 
 \* BEGIN TRANSLATION PCal-e64ab9284c1a4c5172f564abb6f099c4

--- a/test/files/general/load_balancer.tla.expectpcal
+++ b/test/files/general/load_balancer.tla.expectpcal
@@ -240,8 +240,6 @@ CONSTANT WEB_PAGE
       mapping network[_] via TCPChannel;
 }
 
-
-
 \* BEGIN PLUSCAL TRANSLATION
 --algorithm LoadBalancer {
   variables network = [id \in (0) .. ((NUM_NODES) - (1)) |-> <<>>]; in = 0; out = 0; fs = [f \in {in} |-> WEB_PAGE];
@@ -335,7 +333,6 @@ CONSTANT WEB_PAGE
 }
 
 \* END PLUSCAL TRANSLATION
-
 
 
 

--- a/test/files/general/proxy.tla.expectpcal
+++ b/test/files/general/proxy.tla.expectpcal
@@ -201,8 +201,6 @@ ASSUME NUM_SERVERS > 0 /\ NUM_CLIENTS > 0
 
 
 
-
-
 \* BEGIN PLUSCAL TRANSLATION
 --algorithm proxy {
   variables network = [id \in NODE_SET, typ \in MSG_TYP_SET |-> [queue |-> <<>>, enabled |-> TRUE]]; fd = [id \in NODE_SET |-> FALSE];
@@ -402,7 +400,6 @@ ASSUME NUM_SERVERS > 0 /\ NUM_CLIENTS > 0
 }
 
 \* END PLUSCAL TRANSLATION
-
 
 
 ********************)

--- a/test/files/general/proxy_w_macro.tla.expectpcal
+++ b/test/files/general/proxy_w_macro.tla.expectpcal
@@ -1,0 +1,686 @@
+------------------------------- MODULE proxy_w_macro -------------------------------
+
+EXTENDS Naturals, Sequences, TLC, FiniteSets
+
+\* CONSTANT BUFFER_SIZE
+CONSTANT NUM_SERVERS
+CONSTANT NUM_CLIENTS
+CONSTANT EXPLORE_FAIL
+CONSTANT F
+
+ASSUME NUM_SERVERS > 0 /\ NUM_CLIENTS > 0
+
+(********************
+
+--mpcal proxy_w_macro {
+    define {
+        FAIL == 100
+        NUM_NODES == NUM_SERVERS + NUM_CLIENTS + 1
+
+        ProxyID == NUM_NODES
+
+        REQ_MSG_TYP == 1
+        RESP_MSG_TYP == 2
+        PROXY_REQ_MSG_TYP == 3
+        PROXY_RESP_MSG_TYP == 4
+
+        NODE_SET == 1..NUM_NODES
+        SERVER_SET == 1..NUM_SERVERS
+        CLIENT_SET == (NUM_SERVERS+1)..(NUM_SERVERS+NUM_CLIENTS)
+
+        MSG_TYP_SET == {REQ_MSG_TYP, RESP_MSG_TYP, PROXY_REQ_MSG_TYP, PROXY_RESP_MSG_TYP}
+    }
+
+    macro mayFail(selfID, netEnabled) {
+        if (EXPLORE_FAIL) {
+            either { skip; } or {
+                netEnabled[selfID] := FALSE;
+                goto failLabel;
+            };
+        };
+    }
+
+    mapping macro ReliableFIFOLink {
+        read {
+            assert $variable.enabled;
+            await Len($variable.queue) > 0;
+            with (msg = Head($variable.queue)) {
+                $variable.queue := Tail($variable.queue);
+                yield msg;
+            };
+        }
+
+        write {
+            await $variable.enabled;
+            yield [queue |-> Append($variable.queue, $value), enabled |-> $variable.enabled];
+        }
+    }
+
+    mapping macro NetworkToggle {
+        read { yield $variable.enabled; }
+
+        write {
+            yield [queue |-> $variable.queue, enabled |-> $value];
+        }
+    }
+
+    mapping macro PerfectFD {
+        read {
+            yield $variable;
+        }
+
+        write { yield $value; }
+    }
+
+    archetype AProxy(ref net[_], ref fd[_])
+    variables
+        msg, proxyMsg, idx, resp, proxyResp;
+    {
+    proxyLoop:
+        while(TRUE) {
+        rcvMsgFromClient:
+            msg := net[<<ProxyID, REQ_MSG_TYP>>];
+
+        proxyMsg:
+            assert(msg.to = ProxyID /\ msg.typ = REQ_MSG_TYP);
+            proxyResp := [from |-> ProxyID, to |-> msg.from, body |-> FAIL,
+                          id |-> msg.id, typ |-> PROXY_RESP_MSG_TYP];
+            idx := 1;
+            serversLoop:
+                while (idx <= NUM_SERVERS) {
+                proxySendMsg:
+                    either {
+                        proxyMsg := [from |-> ProxyID, to |-> idx, body |-> msg.body,
+                                     id |-> msg.id, typ |-> PROXY_REQ_MSG_TYP];
+                        net[<<proxyMsg.to, PROXY_REQ_MSG_TYP>>] := proxyMsg;
+                    } or {
+                        await fd[idx];
+                        idx := idx + 1;
+                        goto serversLoop;
+                    };
+
+                proxyRcvMsg:
+                    either {
+                        proxyResp := net[<<ProxyID, PROXY_RESP_MSG_TYP>>];
+                        assert(
+                            /\ proxyResp.to = ProxyID
+                            /\ proxyResp.from = idx
+                            /\ proxyResp.id = msg.id
+                            /\ proxyResp.typ = PROXY_RESP_MSG_TYP
+                        );
+                        goto sendMsgToClient;
+                    } or {
+                        await fd[idx];
+                        idx := idx + 1;
+                    };
+                };
+
+        sendMsgToClient:
+            resp := [from |-> ProxyID, to |-> msg.from, body |-> proxyResp.body,
+                     id |-> proxyResp.id, typ |-> RESP_MSG_TYP];
+            net[<<resp.to, resp.typ>>] := resp;
+        };
+    }
+
+    archetype AServer(ref net[_], ref netEnabled[_], ref fd[_])
+    variables
+        msg, resp;
+    {
+    serverLoop:
+        while (TRUE) {
+            mayFail(self, netEnabled);
+
+        serverRcvMsg:
+            msg := net[<<self, PROXY_REQ_MSG_TYP>>];
+            assert(
+                /\ msg.to = self
+                /\ msg.from = ProxyID
+                /\ msg.typ = PROXY_REQ_MSG_TYP
+            );
+            mayFail(self, netEnabled);
+
+        serverSendMsg:
+            resp := [from |-> self, to |-> msg.from, body |-> self,
+                     id |-> msg.id, typ |-> PROXY_RESP_MSG_TYP];
+            net[<<resp.to, resp.typ>>] := resp;
+            mayFail(self, netEnabled);
+        };
+
+    failLabel:
+        fd[self] := TRUE;
+    }
+
+    archetype AClient(ref net[_])
+    variables
+        req, resp;
+    {
+    clientLoop:
+        while (TRUE) {
+        clientSendReq:
+            req := [from |-> self, to |-> ProxyID, body |-> self,
+                    id |-> 0, typ |-> REQ_MSG_TYP];
+            net[<<req.to, req.typ>>] := req;
+            print <<"CLIENT START", req>>;
+
+        clientRcvResp:
+            resp := net[<<self, RESP_MSG_TYP>>];
+            assert(
+                /\ resp.to = self
+                /\ resp.id = 0
+                /\ resp.typ = RESP_MSG_TYP
+            );
+            print <<"CLIENT RESP", resp>>;
+        }
+    }
+
+    variables
+        network = [id \in NODE_SET, typ \in MSG_TYP_SET |-> [queue |-> <<>>, enabled |-> TRUE]];
+        fd = [id \in NODE_SET |-> FALSE];
+
+    fair process (Proxy = ProxyID) == instance AProxy(ref network[_], ref fd[_])
+        mapping network[_] via ReliableFIFOLink
+        mapping fd[_] via PerfectFD;
+
+    fair process (Server \in SERVER_SET) == instance AServer(ref network[_], ref network[_], ref fd[_])
+        mapping @1[_] via ReliableFIFOLink
+        mapping @2[_] via NetworkToggle
+        mapping @3[_] via PerfectFD;
+
+    fair process (Client \in CLIENT_SET) == instance AClient(ref network[_])
+        mapping network[_] via ReliableFIFOLink;
+}
+
+\* BEGIN PLUSCAL TRANSLATION
+--algorithm proxy_w_macro {
+  variables network = [id \in NODE_SET, typ \in MSG_TYP_SET |-> [queue |-> <<>>, enabled |-> TRUE]]; fd = [id \in NODE_SET |-> FALSE];
+  define{
+    FAIL == 100
+    NUM_NODES == ((NUM_SERVERS) + (NUM_CLIENTS)) + (1)
+    ProxyID == NUM_NODES
+    REQ_MSG_TYP == 1
+    RESP_MSG_TYP == 2
+    PROXY_REQ_MSG_TYP == 3
+    PROXY_RESP_MSG_TYP == 4
+    NODE_SET == (1) .. (NUM_NODES)
+    SERVER_SET == (1) .. (NUM_SERVERS)
+    CLIENT_SET == ((NUM_SERVERS) + (1)) .. ((NUM_SERVERS) + (NUM_CLIENTS))
+    MSG_TYP_SET == {REQ_MSG_TYP, RESP_MSG_TYP, PROXY_REQ_MSG_TYP, PROXY_RESP_MSG_TYP}
+  }
+  
+  fair process (Proxy = ProxyID)
+    variables msg; proxyMsg; idx; resp; proxyResp;
+  {
+    proxyLoop:
+      if(TRUE) {
+        goto rcvMsgFromClient;
+      } else {
+        goto Done;
+      };
+    rcvMsgFromClient:
+      assert ((network)[<<ProxyID, REQ_MSG_TYP>>]).enabled;
+      await (Len(((network)[<<ProxyID, REQ_MSG_TYP>>]).queue)) > (0);
+      with (msg0 = Head(((network)[<<ProxyID, REQ_MSG_TYP>>]).queue)) {
+        network := [network EXCEPT !["queue"][<<ProxyID, REQ_MSG_TYP>>] = Tail(((network)[<<ProxyID, REQ_MSG_TYP>>]).queue)];
+        with (yielded_net3 = msg0) {
+          msg := yielded_net3;
+          goto proxyMsg;
+        };
+      };
+    proxyMsg:
+      assert (((msg).to) = (ProxyID)) /\ (((msg).typ) = (REQ_MSG_TYP));
+      proxyResp := [from |-> ProxyID, to |-> (msg).from, body |-> FAIL, id |-> (msg).id, typ |-> PROXY_RESP_MSG_TYP];
+      idx := 1;
+      goto serversLoop;
+    serversLoop:
+      if((idx) <= (NUM_SERVERS)) {
+        goto proxySendMsg;
+      } else {
+        goto sendMsgToClient;
+      };
+    proxySendMsg:
+      either {
+        proxyMsg := [from |-> ProxyID, to |-> idx, body |-> (msg).body, id |-> (msg).id, typ |-> PROXY_REQ_MSG_TYP];
+        with (value7 = proxyMsg) {
+          await ((network)[<<(proxyMsg).to, PROXY_REQ_MSG_TYP>>]).enabled;
+          network := [network EXCEPT ![<<(proxyMsg).to, PROXY_REQ_MSG_TYP>>] = [queue |-> Append(((network)[<<(proxyMsg).to, PROXY_REQ_MSG_TYP>>]).queue, value7), enabled |-> ((network)[<<(proxyMsg).to, PROXY_REQ_MSG_TYP>>]).enabled]];
+          goto proxyRcvMsg;
+        };
+      } or {
+        with (yielded_fd1 = (fd)[idx]) {
+          await yielded_fd1;
+          idx := (idx) + (1);
+          goto serversLoop;
+        };
+      };
+    proxyRcvMsg:
+      either {
+        assert ((network)[<<ProxyID, PROXY_RESP_MSG_TYP>>]).enabled;
+        await (Len(((network)[<<ProxyID, PROXY_RESP_MSG_TYP>>]).queue)) > (0);
+        with (msg1 = Head(((network)[<<ProxyID, PROXY_RESP_MSG_TYP>>]).queue)) {
+          network := [network EXCEPT !["queue"][<<ProxyID, PROXY_RESP_MSG_TYP>>] = Tail(((network)[<<ProxyID, PROXY_RESP_MSG_TYP>>]).queue)];
+          with (yielded_net00 = msg1) {
+            proxyResp := yielded_net00;
+            assert (((((proxyResp).to) = (ProxyID)) /\ (((proxyResp).from) = (idx))) /\ (((proxyResp).id) = ((msg).id))) /\ (((proxyResp).typ) = (PROXY_RESP_MSG_TYP));
+            goto sendMsgToClient;
+          };
+        };
+      } or {
+        with (yielded_fd00 = (fd)[idx]) {
+          await yielded_fd00;
+          idx := (idx) + (1);
+          goto serversLoop;
+        };
+      };
+    sendMsgToClient:
+      resp := [from |-> ProxyID, to |-> (msg).from, body |-> (proxyResp).body, id |-> (proxyResp).id, typ |-> RESP_MSG_TYP];
+      with (value00 = resp) {
+        await ((network)[<<(resp).to, (resp).typ>>]).enabled;
+        network := [network EXCEPT ![<<(resp).to, (resp).typ>>] = [queue |-> Append(((network)[<<(resp).to, (resp).typ>>]).queue, value00), enabled |-> ((network)[<<(resp).to, (resp).typ>>]).enabled]];
+        goto proxyLoop;
+      };
+  }
+  
+  fair process (Server \in SERVER_SET)
+    variables msg; resp;
+  {
+    serverLoop:
+      if(TRUE) {
+        if(EXPLORE_FAIL) {
+          either {
+            skip;
+            goto serverRcvMsg;
+          } or {
+            with (value10 = FALSE) {
+              network := [network EXCEPT ![self] = [queue |-> ((network)[self]).queue, enabled |-> value10]];
+              goto failLabel;
+            };
+          };
+        } else {
+          goto serverRcvMsg;
+        };
+      } else {
+        goto failLabel;
+      };
+    serverRcvMsg:
+      assert ((network)[<<self, PROXY_REQ_MSG_TYP>>]).enabled;
+      await (Len(((network)[<<self, PROXY_REQ_MSG_TYP>>]).queue)) > (0);
+      with (msg2 = Head(((network)[<<self, PROXY_REQ_MSG_TYP>>]).queue)) {
+        with (network0 = [network EXCEPT !["queue"][<<self, PROXY_REQ_MSG_TYP>>] = Tail(((network)[<<self, PROXY_REQ_MSG_TYP>>]).queue)]) {
+          with (yielded_net10 = msg2) {
+            msg := yielded_net10;
+            assert ((((msg).to) = (self)) /\ (((msg).from) = (ProxyID))) /\ (((msg).typ) = (PROXY_REQ_MSG_TYP));
+            if(EXPLORE_FAIL) {
+              either {
+                skip;
+                network := network0;
+                goto serverSendMsg;
+              } or {
+                with (value20 = FALSE) {
+                  network := [network0 EXCEPT ![self] = [queue |-> ((network0)[self]).queue, enabled |-> value20]];
+                  goto failLabel;
+                };
+              };
+            } else {
+              network := network0;
+              goto serverSendMsg;
+            };
+          };
+        };
+      };
+    serverSendMsg:
+      resp := [from |-> self, to |-> (msg).from, body |-> self, id |-> (msg).id, typ |-> PROXY_RESP_MSG_TYP];
+      with (value30 = resp) {
+        await ((network)[<<(resp).to, (resp).typ>>]).enabled;
+        with (network1 = [network EXCEPT ![<<(resp).to, (resp).typ>>] = [queue |-> Append(((network)[<<(resp).to, (resp).typ>>]).queue, value30), enabled |-> ((network)[<<(resp).to, (resp).typ>>]).enabled]]) {
+          if(EXPLORE_FAIL) {
+            either {
+              skip;
+              network := network1;
+              goto serverLoop;
+            } or {
+              with (value40 = FALSE) {
+                network := [network1 EXCEPT ![self] = [queue |-> ((network1)[self]).queue, enabled |-> value40]];
+                goto failLabel;
+              };
+            };
+          } else {
+            network := network1;
+            goto serverLoop;
+          };
+        };
+      };
+    failLabel:
+      with (value50 = TRUE) {
+        fd := [fd EXCEPT ![self] = value50];
+        goto Done;
+      };
+  }
+  
+  fair process (Client \in CLIENT_SET)
+    variables req; resp;
+  {
+    clientLoop:
+      if(TRUE) {
+        goto clientSendReq;
+      } else {
+        goto Done;
+      };
+    clientSendReq:
+      req := [from |-> self, to |-> ProxyID, body |-> self, id |-> 0, typ |-> REQ_MSG_TYP];
+      with (value60 = req) {
+        await ((network)[<<(req).to, (req).typ>>]).enabled;
+        network := [network EXCEPT ![<<(req).to, (req).typ>>] = [queue |-> Append(((network)[<<(req).to, (req).typ>>]).queue, value60), enabled |-> ((network)[<<(req).to, (req).typ>>]).enabled]];
+        print <<"CLIENT START", req>>;
+        goto clientRcvResp;
+      };
+    clientRcvResp:
+      assert ((network)[<<self, RESP_MSG_TYP>>]).enabled;
+      await (Len(((network)[<<self, RESP_MSG_TYP>>]).queue)) > (0);
+      with (msg3 = Head(((network)[<<self, RESP_MSG_TYP>>]).queue)) {
+        network := [network EXCEPT !["queue"][<<self, RESP_MSG_TYP>>] = Tail(((network)[<<self, RESP_MSG_TYP>>]).queue)];
+        with (yielded_net20 = msg3) {
+          resp := yielded_net20;
+          assert ((((resp).to) = (self)) /\ (((resp).id) = (0))) /\ (((resp).typ) = (RESP_MSG_TYP));
+          print <<"CLIENT RESP", resp>>;
+          goto clientLoop;
+        };
+      };
+  }
+}
+
+\* END PLUSCAL TRANSLATION
+
+********************)
+\* BEGIN TRANSLATION (chksum(pcal) = "ba6cf426" /\ chksum(tla) = "3fa8c3b5")
+\* Label proxyMsg of process Proxy at line 199 col 21 changed to proxyMsg_
+\* Process variable msg of process Proxy at line 185 col 15 changed to msg_
+\* Process variable resp of process Proxy at line 185 col 35 changed to resp_
+\* Process variable resp of process Server at line 258 col 20 changed to resp_S
+CONSTANT defaultInitValue
+VARIABLES network, fd, netRead, netWrite, netWrite0, netWrite1, netWrite2,
+          netWrite3, netRead0, netWrite4, netWrite5, netWrite6, netRead1, pc
+
+(* define statement *)
+FAIL == 100
+NUM_NODES == ((NUM_SERVERS) + (NUM_CLIENTS)) + (1)
+ProxyID == NUM_NODES
+REQ_MSG_TYP == 1
+RESP_MSG_TYP == 2
+PROXY_REQ_MSG_TYP == 3
+PROXY_RESP_MSG_TYP == 4
+NODE_SET == (1) .. (NUM_NODES)
+SERVER_SET == (1) .. (NUM_SERVERS)
+CLIENT_SET == ((NUM_SERVERS) + (1)) .. ((NUM_SERVERS) + (NUM_CLIENTS))
+MSG_TYP_SET == {REQ_MSG_TYP, RESP_MSG_TYP, PROXY_REQ_MSG_TYP, PROXY_RESP_MSG_TYP}
+
+VARIABLES msg_, proxyMsg, idx, resp_, proxyResp, msg, resp_S, req, resp
+
+vars == << network, fd, netRead, netWrite, netWrite0, netWrite1, netWrite2,
+           netWrite3, netRead0, netWrite4, netWrite5, netWrite6, netRead1, pc,
+           msg_, proxyMsg, idx, resp_, proxyResp, msg, resp_S, req, resp >>
+
+ProcSet == {ProxyID} \cup (SERVER_SET) \cup (CLIENT_SET)
+
+Init == (* Global variables *)
+        /\ network = [id \in NODE_SET, typ \in MSG_TYP_SET |-> <<>>]
+        /\ fd = [id \in NODE_SET |-> TRUE]
+        /\ netRead = defaultInitValue
+        /\ netWrite = defaultInitValue
+        /\ netWrite0 = defaultInitValue
+        /\ netWrite1 = defaultInitValue
+        /\ netWrite2 = defaultInitValue
+        /\ netWrite3 = defaultInitValue
+        /\ netRead0 = defaultInitValue
+        /\ netWrite4 = defaultInitValue
+        /\ netWrite5 = defaultInitValue
+        /\ netWrite6 = defaultInitValue
+        /\ netRead1 = defaultInitValue
+        (* Process Proxy *)
+        /\ msg_ = defaultInitValue
+        /\ proxyMsg = defaultInitValue
+        /\ idx = defaultInitValue
+        /\ resp_ = defaultInitValue
+        /\ proxyResp = defaultInitValue
+        (* Process Server *)
+        /\ msg = [self \in SERVER_SET |-> defaultInitValue]
+        /\ resp_S = [self \in SERVER_SET |-> defaultInitValue]
+        (* Process Client *)
+        /\ req = [self \in CLIENT_SET |-> defaultInitValue]
+        /\ resp = [self \in CLIENT_SET |-> defaultInitValue]
+        /\ pc = [self \in ProcSet |-> CASE self = ProxyID -> "proxyLoop"
+                                        [] self \in SERVER_SET -> "serverLoop"
+                                        [] self \in CLIENT_SET -> "clientSendReq"]
+
+proxyLoop == /\ pc[ProxyID] = "proxyLoop"
+             /\ IF TRUE
+                   THEN /\ pc' = [pc EXCEPT ![ProxyID] = "rcvMsgFromClient"]
+                        /\ UNCHANGED << network, netWrite3 >>
+                   ELSE /\ netWrite3' = network
+                        /\ network' = netWrite3'
+                        /\ pc' = [pc EXCEPT ![ProxyID] = "Done"]
+             /\ UNCHANGED << fd, netRead, netWrite, netWrite0, netWrite1,
+                             netWrite2, netRead0, netWrite4, netWrite5,
+                             netWrite6, netRead1, msg_, proxyMsg, idx, resp_,
+                             proxyResp, msg, resp_S, req, resp >>
+
+rcvMsgFromClient == /\ pc[ProxyID] = "rcvMsgFromClient"
+                    /\ (Len(network[<<ProxyID, REQ_MSG_TYP>>])) > (0)
+                    /\ LET msg0 == Head(network[<<ProxyID, REQ_MSG_TYP>>]) IN
+                         /\ netWrite' = [network EXCEPT ![<<ProxyID, REQ_MSG_TYP>>] = Tail(network[<<ProxyID, REQ_MSG_TYP>>])]
+                         /\ netRead' = msg0
+                    /\ msg_' = netRead'
+                    /\ network' = netWrite'
+                    /\ pc' = [pc EXCEPT ![ProxyID] = "proxyMsg_"]
+                    /\ UNCHANGED << fd, netWrite0, netWrite1, netWrite2,
+                                    netWrite3, netRead0, netWrite4, netWrite5,
+                                    netWrite6, netRead1, proxyMsg, idx, resp_,
+                                    proxyResp, msg, resp_S, req, resp >>
+
+proxyMsg_ == /\ pc[ProxyID] = "proxyMsg_"
+             /\ Assert((((msg_).to) = (ProxyID)) /\ (((msg_).typ) = (REQ_MSG_TYP)),
+                       "Failure of assertion at line 199, column 21.")
+             /\ proxyResp' = [from |-> ProxyID, to |-> (msg_).from, body |-> FAIL, id |-> (msg_).id, typ |-> PROXY_RESP_MSG_TYP]
+             /\ idx' = 1
+             /\ pc' = [pc EXCEPT ![ProxyID] = "serversLoop"]
+             /\ UNCHANGED << network, fd, netRead, netWrite, netWrite0,
+                             netWrite1, netWrite2, netWrite3, netRead0,
+                             netWrite4, netWrite5, netWrite6, netRead1, msg_,
+                             proxyMsg, resp_, msg, resp_S, req, resp >>
+
+serversLoop == /\ pc[ProxyID] = "serversLoop"
+               /\ IF (idx) <= (NUM_SERVERS)
+                     THEN /\ pc' = [pc EXCEPT ![ProxyID] = "proxySendMsg"]
+                          /\ UNCHANGED << network, netWrite2 >>
+                     ELSE /\ netWrite2' = network
+                          /\ network' = netWrite2'
+                          /\ pc' = [pc EXCEPT ![ProxyID] = "sendMsgToClient"]
+               /\ UNCHANGED << fd, netRead, netWrite, netWrite0, netWrite1,
+                               netWrite3, netRead0, netWrite4, netWrite5,
+                               netWrite6, netRead1, msg_, proxyMsg, idx, resp_,
+                               proxyResp, msg, resp_S, req, resp >>
+
+proxySendMsg == /\ pc[ProxyID] = "proxySendMsg"
+                /\ \/ /\ proxyMsg' = [from |-> ProxyID, to |-> idx, body |-> (msg_).body, id |-> (msg_).id, typ |-> PROXY_REQ_MSG_TYP]
+                      /\ (Len(network[<<(proxyMsg').to, PROXY_REQ_MSG_TYP>>])) < (BUFFER_SIZE)
+                      /\ netWrite' = [network EXCEPT ![<<(proxyMsg').to, PROXY_REQ_MSG_TYP>>] = Append(network[<<(proxyMsg').to, PROXY_REQ_MSG_TYP>>], proxyMsg')]
+                      /\ netWrite0' = netWrite'
+                      /\ network' = netWrite0'
+                      /\ pc' = [pc EXCEPT ![ProxyID] = "proxyRcvMsg"]
+                      /\ idx' = idx
+                   \/ /\ idx' = (idx) + (1)
+                      /\ netWrite0' = network
+                      /\ network' = netWrite0'
+                      /\ pc' = [pc EXCEPT ![ProxyID] = "serversLoop"]
+                      /\ UNCHANGED <<netWrite, proxyMsg>>
+                /\ UNCHANGED << fd, netRead, netWrite1, netWrite2, netWrite3,
+                                netRead0, netWrite4, netWrite5, netWrite6,
+                                netRead1, msg_, resp_, proxyResp, msg, resp_S,
+                                req, resp >>
+
+proxyRcvMsg == /\ pc[ProxyID] = "proxyRcvMsg"
+               /\ \/ /\ (Len(network[<<ProxyID, PROXY_RESP_MSG_TYP>>])) > (0)
+                     /\ LET msg1 == Head(network[<<ProxyID, PROXY_RESP_MSG_TYP>>]) IN
+                          /\ netWrite' = [network EXCEPT ![<<ProxyID, PROXY_RESP_MSG_TYP>>] = Tail(network[<<ProxyID, PROXY_RESP_MSG_TYP>>])]
+                          /\ netRead' = msg1
+                     /\ proxyResp' = netRead'
+                     /\ ((proxyResp').from) = (idx)
+                     /\ Assert((((((proxyResp').to) = (ProxyID)) /\ (((proxyResp').from) = (idx))) /\ (((proxyResp').id) = ((msg_).id))) /\ (((proxyResp').typ) = (PROXY_RESP_MSG_TYP)),
+                               "Failure of assertion at line 228, column 33.")
+                     /\ netWrite1' = netWrite'
+                     /\ network' = netWrite1'
+                     /\ pc' = [pc EXCEPT ![ProxyID] = "sendMsgToClient"]
+                     /\ idx' = idx
+                  \/ /\ idx' = (idx) + (1)
+                     /\ netWrite1' = network
+                     /\ network' = netWrite1'
+                     /\ pc' = [pc EXCEPT ![ProxyID] = "serversLoop"]
+                     /\ UNCHANGED <<netRead, netWrite, proxyResp>>
+               /\ UNCHANGED << fd, netWrite0, netWrite2, netWrite3, netRead0,
+                               netWrite4, netWrite5, netWrite6, netRead1, msg_,
+                               proxyMsg, resp_, msg, resp_S, req, resp >>
+
+sendMsgToClient == /\ pc[ProxyID] = "sendMsgToClient"
+                   /\ resp_' = [from |-> ProxyID, to |-> (msg_).from, body |-> (proxyResp).body, id |-> (proxyResp).id, typ |-> RESP_MSG_TYP]
+                   /\ (Len(network[<<(resp_').to, (resp_').typ>>])) < (BUFFER_SIZE)
+                   /\ netWrite' = [network EXCEPT ![<<(resp_').to, (resp_').typ>>] = Append(network[<<(resp_').to, (resp_').typ>>], resp_')]
+                   /\ network' = netWrite'
+                   /\ pc' = [pc EXCEPT ![ProxyID] = "proxyLoop"]
+                   /\ UNCHANGED << fd, netRead, netWrite0, netWrite1,
+                                   netWrite2, netWrite3, netRead0, netWrite4,
+                                   netWrite5, netWrite6, netRead1, msg_,
+                                   proxyMsg, idx, proxyResp, msg, resp_S, req,
+                                   resp >>
+
+Proxy == proxyLoop \/ rcvMsgFromClient \/ proxyMsg_ \/ serversLoop
+            \/ proxySendMsg \/ proxyRcvMsg \/ sendMsgToClient
+
+serverLoop(self) == /\ pc[self] = "serverLoop"
+                    /\ IF TRUE
+                          THEN /\ IF EXPLORE_FAIL
+                                     THEN /\ \/ /\ TRUE
+                                                /\ pc' = [pc EXCEPT ![self] = "serverRcvMsg"]
+                                             \/ /\ pc' = [pc EXCEPT ![self] = "failLabel"]
+                                     ELSE /\ pc' = [pc EXCEPT ![self] = "serverRcvMsg"]
+                               /\ UNCHANGED << network, netWrite5 >>
+                          ELSE /\ netWrite5' = network
+                               /\ network' = netWrite5'
+                               /\ pc' = [pc EXCEPT ![self] = "failLabel"]
+                    /\ UNCHANGED << fd, netRead, netWrite, netWrite0,
+                                    netWrite1, netWrite2, netWrite3, netRead0,
+                                    netWrite4, netWrite6, netRead1, msg_,
+                                    proxyMsg, idx, resp_, proxyResp, msg,
+                                    resp_S, req, resp >>
+
+serverRcvMsg(self) == /\ pc[self] = "serverRcvMsg"
+                      /\ (Len(network[<<self, PROXY_REQ_MSG_TYP>>])) > (0)
+                      /\ LET msg2 == Head(network[<<self, PROXY_REQ_MSG_TYP>>]) IN
+                           /\ netWrite4' = [network EXCEPT ![<<self, PROXY_REQ_MSG_TYP>>] = Tail(network[<<self, PROXY_REQ_MSG_TYP>>])]
+                           /\ netRead0' = msg2
+                      /\ msg' = [msg EXCEPT ![self] = netRead0']
+                      /\ Assert(((((msg'[self]).to) = (self)) /\ (((msg'[self]).from) = (ProxyID))) /\ (((msg'[self]).typ) = (PROXY_REQ_MSG_TYP)),
+                                "Failure of assertion at line 276, column 21.")
+                      /\ IF EXPLORE_FAIL
+                            THEN /\ \/ /\ network' = netWrite4'
+                                       /\ pc' = [pc EXCEPT ![self] = "serverSendMsg"]
+                                    \/ /\ network' = netWrite4'
+                                       /\ pc' = [pc EXCEPT ![self] = "failLabel"]
+                            ELSE /\ network' = netWrite4'
+                                 /\ pc' = [pc EXCEPT ![self] = "serverSendMsg"]
+                      /\ UNCHANGED << fd, netRead, netWrite, netWrite0,
+                                      netWrite1, netWrite2, netWrite3,
+                                      netWrite5, netWrite6, netRead1, msg_,
+                                      proxyMsg, idx, resp_, proxyResp, resp_S,
+                                      req, resp >>
+
+serverSendMsg(self) == /\ pc[self] = "serverSendMsg"
+                       /\ resp_S' = [resp_S EXCEPT ![self] = [from |-> self, to |-> (msg[self]).from, body |-> self, id |-> (msg[self]).id, typ |-> PROXY_RESP_MSG_TYP]]
+                       /\ (Len(network[<<(resp_S'[self]).to, (resp_S'[self]).typ>>])) < (BUFFER_SIZE)
+                       /\ netWrite4' = [network EXCEPT ![<<(resp_S'[self]).to, (resp_S'[self]).typ>>] = Append(network[<<(resp_S'[self]).to, (resp_S'[self]).typ>>], resp_S'[self])]
+                       /\ IF EXPLORE_FAIL
+                             THEN /\ \/ /\ network' = netWrite4'
+                                        /\ pc' = [pc EXCEPT ![self] = "serverLoop"]
+                                     \/ /\ network' = netWrite4'
+                                        /\ pc' = [pc EXCEPT ![self] = "failLabel"]
+                             ELSE /\ network' = netWrite4'
+                                  /\ pc' = [pc EXCEPT ![self] = "serverLoop"]
+                       /\ UNCHANGED << fd, netRead, netWrite, netWrite0,
+                                       netWrite1, netWrite2, netWrite3,
+                                       netRead0, netWrite5, netWrite6,
+                                       netRead1, msg_, proxyMsg, idx, resp_,
+                                       proxyResp, msg, req, resp >>
+
+failLabel(self) == /\ pc[self] = "failLabel"
+                   /\ TRUE
+                   /\ pc' = [pc EXCEPT ![self] = "Done"]
+                   /\ UNCHANGED << network, fd, netRead, netWrite, netWrite0,
+                                   netWrite1, netWrite2, netWrite3, netRead0,
+                                   netWrite4, netWrite5, netWrite6, netRead1,
+                                   msg_, proxyMsg, idx, resp_, proxyResp, msg,
+                                   resp_S, req, resp >>
+
+Server(self) == serverLoop(self) \/ serverRcvMsg(self)
+                   \/ serverSendMsg(self) \/ failLabel(self)
+
+clientSendReq(self) == /\ pc[self] = "clientSendReq"
+                       /\ req' = [req EXCEPT ![self] = [from |-> self, to |-> ProxyID, body |-> self, id |-> 0, typ |-> REQ_MSG_TYP]]
+                       /\ (Len(network[<<(req'[self]).to, (req'[self]).typ>>])) < (BUFFER_SIZE)
+                       /\ netWrite6' = [network EXCEPT ![<<(req'[self]).to, (req'[self]).typ>>] = Append(network[<<(req'[self]).to, (req'[self]).typ>>], req'[self])]
+                       /\ network' = netWrite6'
+                       /\ pc' = [pc EXCEPT ![self] = "clientRcvResp"]
+                       /\ UNCHANGED << fd, netRead, netWrite, netWrite0,
+                                       netWrite1, netWrite2, netWrite3,
+                                       netRead0, netWrite4, netWrite5,
+                                       netRead1, msg_, proxyMsg, idx, resp_,
+                                       proxyResp, msg, resp_S, resp >>
+
+clientRcvResp(self) == /\ pc[self] = "clientRcvResp"
+                       /\ (Len(network[<<self, RESP_MSG_TYP>>])) > (0)
+                       /\ LET msg3 == Head(network[<<self, RESP_MSG_TYP>>]) IN
+                            /\ netWrite6' = [network EXCEPT ![<<self, RESP_MSG_TYP>>] = Tail(network[<<self, RESP_MSG_TYP>>])]
+                            /\ netRead1' = msg3
+                       /\ resp' = [resp EXCEPT ![self] = netRead1']
+                       /\ Assert(((((resp'[self]).to) = (self)) /\ (((resp'[self]).id) = (0))) /\ (((resp'[self]).typ) = (RESP_MSG_TYP)),
+                                 "Failure of assertion at line 328, column 13.")
+                       /\ network' = netWrite6'
+                       /\ pc' = [pc EXCEPT ![self] = "Done"]
+                       /\ UNCHANGED << fd, netRead, netWrite, netWrite0,
+                                       netWrite1, netWrite2, netWrite3,
+                                       netRead0, netWrite4, netWrite5, msg_,
+                                       proxyMsg, idx, resp_, proxyResp, msg,
+                                       resp_S, req >>
+
+Client(self) == clientSendReq(self) \/ clientRcvResp(self)
+
+(* Allow infinite stuttering to prevent deadlock on termination. *)
+Terminating == /\ \A self \in ProcSet: pc[self] = "Done"
+               /\ UNCHANGED vars
+
+Next == Proxy
+           \/ (\E self \in SERVER_SET: Server(self))
+           \/ (\E self \in CLIENT_SET: Client(self))
+           \/ Terminating
+
+Spec == /\ Init /\ [][Next]_vars
+        /\ WF_vars(Proxy)
+        /\ \A self \in SERVER_SET : WF_vars(Server(self))
+        /\ \A self \in CLIENT_SET : WF_vars(Client(self))
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION
+
+
+\* Invariants
+
+\* BufferOK(node, typ) == Len(network[node, typ]) >= 0 /\ Len(network[node, typ]) <= BUFFER_SIZE
+\* BuffersOK == \A <<node, typ>> \in DOMAIN network : BufferOK(node, typ)
+
+\* Properties
+
+ReceiveResp(client) == pc[client] = "clientSendReq" ~> pc[client] = "clientRcvResp"
+ClientsOK == \A client \in CLIENT_SET : ReceiveResp(client)
+
+=============================================================================
+\* Modification History
+\* Last modified Tue Aug 03 18:29:38 PDT 2021 by shayan
+\* Created Wed Jun 30 19:19:46 PDT 2021 by shayan

--- a/test/files/general/proxy_w_macro.tla.gotests/proxy_w_macro.go
+++ b/test/files/general/proxy_w_macro.tla.gotests/proxy_w_macro.go
@@ -1,943 +1,942 @@
 package proxy_w_macro
 
 import (
-  "github.com/UBC-NSS/pgo/distsys"
-  "fmt"
+	"fmt"
+	"github.com/UBC-NSS/pgo/distsys"
 )
 
-var _ = new(fmt.Stringer) // unconditionally prevent go compiler from reporting unused fmt import
+var _ = new(fmt.Stringer)  // unconditionally prevent go compiler from reporting unused fmt import
 var _ = distsys.TLAValue{} // same, for distsys
 
 type Constants struct {
-  NUM_SERVERS distsys.TLAValue
-  NUM_CLIENTS distsys.TLAValue
-  EXPLORE_FAIL distsys.TLAValue
-  F distsys.TLAValue
+	NUM_SERVERS  distsys.TLAValue
+	NUM_CLIENTS  distsys.TLAValue
+	EXPLORE_FAIL distsys.TLAValue
+	F            distsys.TLAValue
 }
 
 func FAIL(constants Constants) distsys.TLAValue {
-  return distsys.NewTLANumber(100)
+	return distsys.NewTLANumber(100)
 }
 
 func NUM_NODES(constants Constants) distsys.TLAValue {
-  return distsys.TLA_PlusSymbol(distsys.TLA_PlusSymbol(constants.NUM_SERVERS, constants.NUM_CLIENTS), distsys.NewTLANumber(1))
+	return distsys.TLA_PlusSymbol(distsys.TLA_PlusSymbol(constants.NUM_SERVERS, constants.NUM_CLIENTS), distsys.NewTLANumber(1))
 }
 
 func ProxyID(constants Constants) distsys.TLAValue {
-  return func() distsys.TLAValue {
-    return NUM_NODES(constants)
-  }()
+	return func() distsys.TLAValue {
+		return NUM_NODES(constants)
+	}()
 }
 
 func REQ_MSG_TYP(constants Constants) distsys.TLAValue {
-  return distsys.NewTLANumber(1)
+	return distsys.NewTLANumber(1)
 }
 
 func RESP_MSG_TYP(constants Constants) distsys.TLAValue {
-  return distsys.NewTLANumber(2)
+	return distsys.NewTLANumber(2)
 }
 
 func PROXY_REQ_MSG_TYP(constants Constants) distsys.TLAValue {
-  return distsys.NewTLANumber(3)
+	return distsys.NewTLANumber(3)
 }
 
 func PROXY_RESP_MSG_TYP(constants Constants) distsys.TLAValue {
-  return distsys.NewTLANumber(4)
+	return distsys.NewTLANumber(4)
 }
 
 func NODE_SET(constants Constants) distsys.TLAValue {
-  return distsys.TLA_DotDotSymbol(distsys.NewTLANumber(1), func() distsys.TLAValue {
-    return NUM_NODES(constants)
-  }())
+	return distsys.TLA_DotDotSymbol(distsys.NewTLANumber(1), func() distsys.TLAValue {
+		return NUM_NODES(constants)
+	}())
 }
 
 func SERVER_SET(constants Constants) distsys.TLAValue {
-  return distsys.TLA_DotDotSymbol(distsys.NewTLANumber(1), constants.NUM_SERVERS)
+	return distsys.TLA_DotDotSymbol(distsys.NewTLANumber(1), constants.NUM_SERVERS)
 }
 
 func CLIENT_SET(constants Constants) distsys.TLAValue {
-  return distsys.TLA_DotDotSymbol(distsys.TLA_PlusSymbol(constants.NUM_SERVERS, distsys.NewTLANumber(1)), distsys.TLA_PlusSymbol(constants.NUM_SERVERS, constants.NUM_CLIENTS))
+	return distsys.TLA_DotDotSymbol(distsys.TLA_PlusSymbol(constants.NUM_SERVERS, distsys.NewTLANumber(1)), distsys.TLA_PlusSymbol(constants.NUM_SERVERS, constants.NUM_CLIENTS))
 }
 
 func MSG_TYP_SET(constants Constants) distsys.TLAValue {
-  return distsys.NewTLASet(func() distsys.TLAValue {
-    return REQ_MSG_TYP(constants)
-  }(), func() distsys.TLAValue {
-    return RESP_MSG_TYP(constants)
-  }(), func() distsys.TLAValue {
-    return PROXY_REQ_MSG_TYP(constants)
-  }(), func() distsys.TLAValue {
-    return PROXY_RESP_MSG_TYP(constants)
-  }())
+	return distsys.NewTLASet(func() distsys.TLAValue {
+		return REQ_MSG_TYP(constants)
+	}(), func() distsys.TLAValue {
+		return RESP_MSG_TYP(constants)
+	}(), func() distsys.TLAValue {
+		return PROXY_REQ_MSG_TYP(constants)
+	}(), func() distsys.TLAValue {
+		return PROXY_RESP_MSG_TYP(constants)
+	}())
 }
 
-
 func AProxy(ctx *distsys.MPCalContext, self distsys.TLAValue, constants Constants, net distsys.ArchetypeResourceHandle, fd distsys.ArchetypeResourceHandle) error {
-  var err error
-  // label tags
-  const (
-    InitLabelTag = iota
-    proxyLoopLabelTag
-    rcvMsgFromClientLabelTag
-    proxyMsgLabelTag
-    serversLoopLabelTag
-    proxySendMsgLabelTag
-    proxyRcvMsgLabelTag
-    sendMsgToClientLabelTag
-    DoneLabelTag
-  )
-  programCounter := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.NewTLANumber(InitLabelTag)))
-  msg := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
-  _ = msg
-  proxyMsg0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
-  _ = proxyMsg0
-  idx := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
-  _ = idx
-  resp := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
-  _ = resp
-  proxyResp := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
-  _ = proxyResp
-  var fairnessCounter int = 0
-  var fairnessCounter0 int = 0
-  
-  for {
-    if err != nil {
-      if err == distsys.ErrCriticalSectionAborted {
-        ctx.Abort()
-        err = nil
-      } else {
-        return err
-      }
-    }
-    var labelTag distsys.TLAValue
-    labelTag, err = ctx.Read(programCounter, []distsys.TLAValue{})
-    if err != nil {
-      return err
-    }
-    switch labelTag.AsNumber() {
-    case InitLabelTag:
-      err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyLoopLabelTag))
-      if err != nil {
-        continue
-      }
-    case proxyLoopLabelTag:
-      if distsys.TLA_TRUE.AsBool() {
-        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(rcvMsgFromClientLabelTag))
-        if err != nil {
-          continue
-        }
-        err = ctx.Commit()
-        if err != nil {
-          continue
-        }
-      } else {
-        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(DoneLabelTag))
-        if err != nil {
-          continue
-        }
-        err = ctx.Commit()
-        if err != nil {
-          continue
-        }
-      }
-      // no statements
-    case rcvMsgFromClientLabelTag:
-      var exprRead distsys.TLAValue
-      exprRead, err = ctx.Read(net, []distsys.TLAValue{distsys.NewTLATuple(func() distsys.TLAValue {
-        return ProxyID(constants)
-      }(), func() distsys.TLAValue {
-        return REQ_MSG_TYP(constants)
-      }())})
-      if err != nil {
-        continue
-      }
-      err = ctx.Write(msg, []distsys.TLAValue{}, exprRead)
-      if err != nil {
-        continue
-      }
-      err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyMsgLabelTag))
-      if err != nil {
-        continue
-      }
-      err = ctx.Commit()
-      if err != nil {
-        continue
-      }
-    case proxyMsgLabelTag:
-      var condition distsys.TLAValue
-      condition, err = ctx.Read(msg, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      var condition0 distsys.TLAValue
-      condition0, err = ctx.Read(msg, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      if !distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition.ApplyFunction(distsys.NewTLAString("to")), func() distsys.TLAValue {
-        return ProxyID(constants)
-      }()), distsys.TLA_EqualsSymbol(condition0.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
-        return REQ_MSG_TYP(constants)
-      }())).AsBool() {
-        err = fmt.Errorf("%w: (((msg).to) = (ProxyID)) /\\ (((msg).typ) = (REQ_MSG_TYP))", distsys.ErrAssertionFailed)
-        continue
-      }
-      var exprRead0 distsys.TLAValue
-      exprRead0, err = ctx.Read(msg, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      var exprRead1 distsys.TLAValue
-      exprRead1, err = ctx.Read(msg, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      err = ctx.Write(proxyResp, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
-        {distsys.NewTLAString("from"), func() distsys.TLAValue {
-          return ProxyID(constants)
-        }()},
-        {distsys.NewTLAString("to"), exprRead0.ApplyFunction(distsys.NewTLAString("from"))},
-        {distsys.NewTLAString("body"), func() distsys.TLAValue {
-          return FAIL(constants)
-        }()},
-        {distsys.NewTLAString("id"), exprRead1.ApplyFunction(distsys.NewTLAString("id"))},
-        {distsys.NewTLAString("typ"), func() distsys.TLAValue {
-          return PROXY_RESP_MSG_TYP(constants)
-        }()},
-      }))
-      if err != nil {
-        continue
-      }
-      err = ctx.Write(idx, []distsys.TLAValue{}, distsys.NewTLANumber(1))
-      if err != nil {
-        continue
-      }
-      err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(serversLoopLabelTag))
-      if err != nil {
-        continue
-      }
-      err = ctx.Commit()
-      if err != nil {
-        continue
-      }
-    case serversLoopLabelTag:
-      var condition1 distsys.TLAValue
-      condition1, err = ctx.Read(idx, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      if distsys.TLA_LessThanOrEqualSymbol(condition1, constants.NUM_SERVERS).AsBool() {
-        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxySendMsgLabelTag))
-        if err != nil {
-          continue
-        }
-        err = ctx.Commit()
-        if err != nil {
-          continue
-        }
-      } else {
-        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(sendMsgToClientLabelTag))
-        if err != nil {
-          continue
-        }
-        err = ctx.Commit()
-        if err != nil {
-          continue
-        }
-      }
-      // no statements
-    case proxySendMsgLabelTag:
-      fairnessCounterCurrent := fairnessCounter
-      fairnessCounter = fairnessCounter + 1 % 2
-      switch fairnessCounterCurrent {
-      case 0:
-        var exprRead6 distsys.TLAValue
-        exprRead6, err = ctx.Read(idx, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        var exprRead7 distsys.TLAValue
-        exprRead7, err = ctx.Read(msg, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        var exprRead8 distsys.TLAValue
-        exprRead8, err = ctx.Read(msg, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        err = ctx.Write(proxyMsg0, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
-          {distsys.NewTLAString("from"), func() distsys.TLAValue {
-            return ProxyID(constants)
-          }()},
-          {distsys.NewTLAString("to"), exprRead6},
-          {distsys.NewTLAString("body"), exprRead7.ApplyFunction(distsys.NewTLAString("body"))},
-          {distsys.NewTLAString("id"), exprRead8.ApplyFunction(distsys.NewTLAString("id"))},
-          {distsys.NewTLAString("typ"), func() distsys.TLAValue {
-            return PROXY_REQ_MSG_TYP(constants)
-          }()},
-        }))
-        if err != nil {
-          continue
-        }
-        var exprRead9 distsys.TLAValue
-        exprRead9, err = ctx.Read(proxyMsg0, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        var indexRead1 distsys.TLAValue
-        indexRead1, err = ctx.Read(proxyMsg0, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        err = ctx.Write(net, []distsys.TLAValue{distsys.NewTLATuple(indexRead1.ApplyFunction(distsys.NewTLAString("to")), func() distsys.TLAValue {
-          return PROXY_REQ_MSG_TYP(constants)
-        }())}, exprRead9)
-        if err != nil {
-          continue
-        }
-        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyRcvMsgLabelTag))
-        if err != nil {
-          continue
-        }
-        err = ctx.Commit()
-        if err != nil {
-          continue
-        }
-      case 1:
-        var condition2 distsys.TLAValue
-        condition2, err = ctx.Read(idx, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        var condition3 distsys.TLAValue
-        condition3, err = ctx.Read(fd, []distsys.TLAValue{condition2})
-        if err != nil {
-          continue
-        }
-        if !condition3.AsBool() {
-          err = distsys.ErrCriticalSectionAborted
-          continue
-        }
-        var exprRead10 distsys.TLAValue
-        exprRead10, err = ctx.Read(idx, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        err = ctx.Write(idx, []distsys.TLAValue{}, distsys.TLA_PlusSymbol(exprRead10, distsys.NewTLANumber(1)))
-        if err != nil {
-          continue
-        }
-        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(serversLoopLabelTag))
-        if err != nil {
-          continue
-        }
-        err = ctx.Commit()
-        if err != nil {
-          continue
-        }
-      default:
-        panic("current branch of either matches no code paths!")
-      }
-      // no statements
-    case proxyRcvMsgLabelTag:
-      fairnessCounterCurrent0 := fairnessCounter0
-      fairnessCounter0 = fairnessCounter0 + 1 % 2
-      switch fairnessCounterCurrent0 {
-      case 0:
-        var exprRead11 distsys.TLAValue
-        exprRead11, err = ctx.Read(net, []distsys.TLAValue{distsys.NewTLATuple(func() distsys.TLAValue {
-          return ProxyID(constants)
-        }(), func() distsys.TLAValue {
-          return PROXY_RESP_MSG_TYP(constants)
-        }())})
-        if err != nil {
-          continue
-        }
-        err = ctx.Write(proxyResp, []distsys.TLAValue{}, exprRead11)
-        if err != nil {
-          continue
-        }
-        var condition4 distsys.TLAValue
-        condition4, err = ctx.Read(proxyResp, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        var condition5 distsys.TLAValue
-        condition5, err = ctx.Read(proxyResp, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        var condition6 distsys.TLAValue
-        condition6, err = ctx.Read(idx, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        var condition7 distsys.TLAValue
-        condition7, err = ctx.Read(proxyResp, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        var condition8 distsys.TLAValue
-        condition8, err = ctx.Read(msg, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        var condition9 distsys.TLAValue
-        condition9, err = ctx.Read(proxyResp, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        if !distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition4.ApplyFunction(distsys.NewTLAString("to")), func() distsys.TLAValue {
-          return ProxyID(constants)
-        }()), distsys.TLA_EqualsSymbol(condition5.ApplyFunction(distsys.NewTLAString("from")), condition6)), distsys.TLA_EqualsSymbol(condition7.ApplyFunction(distsys.NewTLAString("id")), condition8.ApplyFunction(distsys.NewTLAString("id")))), distsys.TLA_EqualsSymbol(condition9.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
-          return PROXY_RESP_MSG_TYP(constants)
-        }())).AsBool() {
-          err = fmt.Errorf("%w: (((((proxyResp).to) = (ProxyID)) /\\ (((proxyResp).from) = (idx))) /\\ (((proxyResp).id) = ((msg).id))) /\\ (((proxyResp).typ) = (PROXY_RESP_MSG_TYP))", distsys.ErrAssertionFailed)
-          continue
-        }
-        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(sendMsgToClientLabelTag))
-        if err != nil {
-          continue
-        }
-        err = ctx.Commit()
-        if err != nil {
-          continue
-        }
-      case 1:
-        var condition10 distsys.TLAValue
-        condition10, err = ctx.Read(idx, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        var condition11 distsys.TLAValue
-        condition11, err = ctx.Read(fd, []distsys.TLAValue{condition10})
-        if err != nil {
-          continue
-        }
-        if !condition11.AsBool() {
-          err = distsys.ErrCriticalSectionAborted
-          continue
-        }
-        var exprRead12 distsys.TLAValue
-        exprRead12, err = ctx.Read(idx, []distsys.TLAValue{})
-        if err != nil {
-          continue
-        }
-        err = ctx.Write(idx, []distsys.TLAValue{}, distsys.TLA_PlusSymbol(exprRead12, distsys.NewTLANumber(1)))
-        if err != nil {
-          continue
-        }
-        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(serversLoopLabelTag))
-        if err != nil {
-          continue
-        }
-        err = ctx.Commit()
-        if err != nil {
-          continue
-        }
-      default:
-        panic("current branch of either matches no code paths!")
-      }
-      // no statements
-    case sendMsgToClientLabelTag:
-      var exprRead2 distsys.TLAValue
-      exprRead2, err = ctx.Read(msg, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      var exprRead3 distsys.TLAValue
-      exprRead3, err = ctx.Read(proxyResp, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      var exprRead4 distsys.TLAValue
-      exprRead4, err = ctx.Read(proxyResp, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      err = ctx.Write(resp, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
-        {distsys.NewTLAString("from"), func() distsys.TLAValue {
-          return ProxyID(constants)
-        }()},
-        {distsys.NewTLAString("to"), exprRead2.ApplyFunction(distsys.NewTLAString("from"))},
-        {distsys.NewTLAString("body"), exprRead3.ApplyFunction(distsys.NewTLAString("body"))},
-        {distsys.NewTLAString("id"), exprRead4.ApplyFunction(distsys.NewTLAString("id"))},
-        {distsys.NewTLAString("typ"), func() distsys.TLAValue {
-          return RESP_MSG_TYP(constants)
-        }()},
-      }))
-      if err != nil {
-        continue
-      }
-      var exprRead5 distsys.TLAValue
-      exprRead5, err = ctx.Read(resp, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      var indexRead distsys.TLAValue
-      indexRead, err = ctx.Read(resp, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      var indexRead0 distsys.TLAValue
-      indexRead0, err = ctx.Read(resp, []distsys.TLAValue{})
-      if err != nil {
-        continue
-      }
-      err = ctx.Write(net, []distsys.TLAValue{distsys.NewTLATuple(indexRead.ApplyFunction(distsys.NewTLAString("to")), indexRead0.ApplyFunction(distsys.NewTLAString("typ")))}, exprRead5)
-      if err != nil {
-        continue
-      }
-      err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyLoopLabelTag))
-      if err != nil {
-        continue
-      }
-      err = ctx.Commit()
-      if err != nil {
-        continue
-      }
-    case DoneLabelTag:
-      return nil
-    default:
-      return fmt.Errorf("invalid program counter %v", labelTag)
-    }
-  }
+	var err error
+	// label tags
+	const (
+		InitLabelTag = iota
+		proxyLoopLabelTag
+		rcvMsgFromClientLabelTag
+		proxyMsgLabelTag
+		serversLoopLabelTag
+		proxySendMsgLabelTag
+		proxyRcvMsgLabelTag
+		sendMsgToClientLabelTag
+		DoneLabelTag
+	)
+	programCounter := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.NewTLANumber(InitLabelTag)))
+	msg := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+	_ = msg
+	proxyMsg0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+	_ = proxyMsg0
+	idx := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+	_ = idx
+	resp := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+	_ = resp
+	proxyResp := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+	_ = proxyResp
+	var fairnessCounter int = 0
+	var fairnessCounter0 int = 0
+
+	for {
+		if err != nil {
+			if err == distsys.ErrCriticalSectionAborted {
+				ctx.Abort()
+				err = nil
+			} else {
+				return err
+			}
+		}
+		var labelTag distsys.TLAValue
+		labelTag, err = ctx.Read(programCounter, []distsys.TLAValue{})
+		if err != nil {
+			return err
+		}
+		switch labelTag.AsNumber() {
+		case InitLabelTag:
+			err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyLoopLabelTag))
+			if err != nil {
+				continue
+			}
+		case proxyLoopLabelTag:
+			if distsys.TLA_TRUE.AsBool() {
+				err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(rcvMsgFromClientLabelTag))
+				if err != nil {
+					continue
+				}
+				err = ctx.Commit()
+				if err != nil {
+					continue
+				}
+			} else {
+				err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(DoneLabelTag))
+				if err != nil {
+					continue
+				}
+				err = ctx.Commit()
+				if err != nil {
+					continue
+				}
+			}
+			// no statements
+		case rcvMsgFromClientLabelTag:
+			var exprRead distsys.TLAValue
+			exprRead, err = ctx.Read(net, []distsys.TLAValue{distsys.NewTLATuple(func() distsys.TLAValue {
+				return ProxyID(constants)
+			}(), func() distsys.TLAValue {
+				return REQ_MSG_TYP(constants)
+			}())})
+			if err != nil {
+				continue
+			}
+			err = ctx.Write(msg, []distsys.TLAValue{}, exprRead)
+			if err != nil {
+				continue
+			}
+			err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyMsgLabelTag))
+			if err != nil {
+				continue
+			}
+			err = ctx.Commit()
+			if err != nil {
+				continue
+			}
+		case proxyMsgLabelTag:
+			var condition distsys.TLAValue
+			condition, err = ctx.Read(msg, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			var condition0 distsys.TLAValue
+			condition0, err = ctx.Read(msg, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			if !distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition.ApplyFunction(distsys.NewTLAString("to")), func() distsys.TLAValue {
+				return ProxyID(constants)
+			}()), distsys.TLA_EqualsSymbol(condition0.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
+				return REQ_MSG_TYP(constants)
+			}())).AsBool() {
+				err = fmt.Errorf("%w: (((msg).to) = (ProxyID)) /\\ (((msg).typ) = (REQ_MSG_TYP))", distsys.ErrAssertionFailed)
+				continue
+			}
+			var exprRead0 distsys.TLAValue
+			exprRead0, err = ctx.Read(msg, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			var exprRead1 distsys.TLAValue
+			exprRead1, err = ctx.Read(msg, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			err = ctx.Write(proxyResp, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
+				{distsys.NewTLAString("from"), func() distsys.TLAValue {
+					return ProxyID(constants)
+				}()},
+				{distsys.NewTLAString("to"), exprRead0.ApplyFunction(distsys.NewTLAString("from"))},
+				{distsys.NewTLAString("body"), func() distsys.TLAValue {
+					return FAIL(constants)
+				}()},
+				{distsys.NewTLAString("id"), exprRead1.ApplyFunction(distsys.NewTLAString("id"))},
+				{distsys.NewTLAString("typ"), func() distsys.TLAValue {
+					return PROXY_RESP_MSG_TYP(constants)
+				}()},
+			}))
+			if err != nil {
+				continue
+			}
+			err = ctx.Write(idx, []distsys.TLAValue{}, distsys.NewTLANumber(1))
+			if err != nil {
+				continue
+			}
+			err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(serversLoopLabelTag))
+			if err != nil {
+				continue
+			}
+			err = ctx.Commit()
+			if err != nil {
+				continue
+			}
+		case serversLoopLabelTag:
+			var condition1 distsys.TLAValue
+			condition1, err = ctx.Read(idx, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			if distsys.TLA_LessThanOrEqualSymbol(condition1, constants.NUM_SERVERS).AsBool() {
+				err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxySendMsgLabelTag))
+				if err != nil {
+					continue
+				}
+				err = ctx.Commit()
+				if err != nil {
+					continue
+				}
+			} else {
+				err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(sendMsgToClientLabelTag))
+				if err != nil {
+					continue
+				}
+				err = ctx.Commit()
+				if err != nil {
+					continue
+				}
+			}
+			// no statements
+		case proxySendMsgLabelTag:
+			fairnessCounterCurrent := fairnessCounter
+			fairnessCounter = fairnessCounter + 1%2
+			switch fairnessCounterCurrent {
+			case 0:
+				var exprRead6 distsys.TLAValue
+				exprRead6, err = ctx.Read(idx, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				var exprRead7 distsys.TLAValue
+				exprRead7, err = ctx.Read(msg, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				var exprRead8 distsys.TLAValue
+				exprRead8, err = ctx.Read(msg, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				err = ctx.Write(proxyMsg0, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
+					{distsys.NewTLAString("from"), func() distsys.TLAValue {
+						return ProxyID(constants)
+					}()},
+					{distsys.NewTLAString("to"), exprRead6},
+					{distsys.NewTLAString("body"), exprRead7.ApplyFunction(distsys.NewTLAString("body"))},
+					{distsys.NewTLAString("id"), exprRead8.ApplyFunction(distsys.NewTLAString("id"))},
+					{distsys.NewTLAString("typ"), func() distsys.TLAValue {
+						return PROXY_REQ_MSG_TYP(constants)
+					}()},
+				}))
+				if err != nil {
+					continue
+				}
+				var exprRead9 distsys.TLAValue
+				exprRead9, err = ctx.Read(proxyMsg0, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				var indexRead1 distsys.TLAValue
+				indexRead1, err = ctx.Read(proxyMsg0, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				err = ctx.Write(net, []distsys.TLAValue{distsys.NewTLATuple(indexRead1.ApplyFunction(distsys.NewTLAString("to")), func() distsys.TLAValue {
+					return PROXY_REQ_MSG_TYP(constants)
+				}())}, exprRead9)
+				if err != nil {
+					continue
+				}
+				err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyRcvMsgLabelTag))
+				if err != nil {
+					continue
+				}
+				err = ctx.Commit()
+				if err != nil {
+					continue
+				}
+			case 1:
+				var condition2 distsys.TLAValue
+				condition2, err = ctx.Read(idx, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				var condition3 distsys.TLAValue
+				condition3, err = ctx.Read(fd, []distsys.TLAValue{condition2})
+				if err != nil {
+					continue
+				}
+				if !condition3.AsBool() {
+					err = distsys.ErrCriticalSectionAborted
+					continue
+				}
+				var exprRead10 distsys.TLAValue
+				exprRead10, err = ctx.Read(idx, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				err = ctx.Write(idx, []distsys.TLAValue{}, distsys.TLA_PlusSymbol(exprRead10, distsys.NewTLANumber(1)))
+				if err != nil {
+					continue
+				}
+				err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(serversLoopLabelTag))
+				if err != nil {
+					continue
+				}
+				err = ctx.Commit()
+				if err != nil {
+					continue
+				}
+			default:
+				panic("current branch of either matches no code paths!")
+			}
+			// no statements
+		case proxyRcvMsgLabelTag:
+			fairnessCounterCurrent0 := fairnessCounter0
+			fairnessCounter0 = fairnessCounter0 + 1%2
+			switch fairnessCounterCurrent0 {
+			case 0:
+				var exprRead11 distsys.TLAValue
+				exprRead11, err = ctx.Read(net, []distsys.TLAValue{distsys.NewTLATuple(func() distsys.TLAValue {
+					return ProxyID(constants)
+				}(), func() distsys.TLAValue {
+					return PROXY_RESP_MSG_TYP(constants)
+				}())})
+				if err != nil {
+					continue
+				}
+				err = ctx.Write(proxyResp, []distsys.TLAValue{}, exprRead11)
+				if err != nil {
+					continue
+				}
+				var condition4 distsys.TLAValue
+				condition4, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				var condition5 distsys.TLAValue
+				condition5, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				var condition6 distsys.TLAValue
+				condition6, err = ctx.Read(idx, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				var condition7 distsys.TLAValue
+				condition7, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				var condition8 distsys.TLAValue
+				condition8, err = ctx.Read(msg, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				var condition9 distsys.TLAValue
+				condition9, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				if !distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition4.ApplyFunction(distsys.NewTLAString("to")), func() distsys.TLAValue {
+					return ProxyID(constants)
+				}()), distsys.TLA_EqualsSymbol(condition5.ApplyFunction(distsys.NewTLAString("from")), condition6)), distsys.TLA_EqualsSymbol(condition7.ApplyFunction(distsys.NewTLAString("id")), condition8.ApplyFunction(distsys.NewTLAString("id")))), distsys.TLA_EqualsSymbol(condition9.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
+					return PROXY_RESP_MSG_TYP(constants)
+				}())).AsBool() {
+					err = fmt.Errorf("%w: (((((proxyResp).to) = (ProxyID)) /\\ (((proxyResp).from) = (idx))) /\\ (((proxyResp).id) = ((msg).id))) /\\ (((proxyResp).typ) = (PROXY_RESP_MSG_TYP))", distsys.ErrAssertionFailed)
+					continue
+				}
+				err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(sendMsgToClientLabelTag))
+				if err != nil {
+					continue
+				}
+				err = ctx.Commit()
+				if err != nil {
+					continue
+				}
+			case 1:
+				var condition10 distsys.TLAValue
+				condition10, err = ctx.Read(idx, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				var condition11 distsys.TLAValue
+				condition11, err = ctx.Read(fd, []distsys.TLAValue{condition10})
+				if err != nil {
+					continue
+				}
+				if !condition11.AsBool() {
+					err = distsys.ErrCriticalSectionAborted
+					continue
+				}
+				var exprRead12 distsys.TLAValue
+				exprRead12, err = ctx.Read(idx, []distsys.TLAValue{})
+				if err != nil {
+					continue
+				}
+				err = ctx.Write(idx, []distsys.TLAValue{}, distsys.TLA_PlusSymbol(exprRead12, distsys.NewTLANumber(1)))
+				if err != nil {
+					continue
+				}
+				err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(serversLoopLabelTag))
+				if err != nil {
+					continue
+				}
+				err = ctx.Commit()
+				if err != nil {
+					continue
+				}
+			default:
+				panic("current branch of either matches no code paths!")
+			}
+			// no statements
+		case sendMsgToClientLabelTag:
+			var exprRead2 distsys.TLAValue
+			exprRead2, err = ctx.Read(msg, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			var exprRead3 distsys.TLAValue
+			exprRead3, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			var exprRead4 distsys.TLAValue
+			exprRead4, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			err = ctx.Write(resp, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
+				{distsys.NewTLAString("from"), func() distsys.TLAValue {
+					return ProxyID(constants)
+				}()},
+				{distsys.NewTLAString("to"), exprRead2.ApplyFunction(distsys.NewTLAString("from"))},
+				{distsys.NewTLAString("body"), exprRead3.ApplyFunction(distsys.NewTLAString("body"))},
+				{distsys.NewTLAString("id"), exprRead4.ApplyFunction(distsys.NewTLAString("id"))},
+				{distsys.NewTLAString("typ"), func() distsys.TLAValue {
+					return RESP_MSG_TYP(constants)
+				}()},
+			}))
+			if err != nil {
+				continue
+			}
+			var exprRead5 distsys.TLAValue
+			exprRead5, err = ctx.Read(resp, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			var indexRead distsys.TLAValue
+			indexRead, err = ctx.Read(resp, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			var indexRead0 distsys.TLAValue
+			indexRead0, err = ctx.Read(resp, []distsys.TLAValue{})
+			if err != nil {
+				continue
+			}
+			err = ctx.Write(net, []distsys.TLAValue{distsys.NewTLATuple(indexRead.ApplyFunction(distsys.NewTLAString("to")), indexRead0.ApplyFunction(distsys.NewTLAString("typ")))}, exprRead5)
+			if err != nil {
+				continue
+			}
+			err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyLoopLabelTag))
+			if err != nil {
+				continue
+			}
+			err = ctx.Commit()
+			if err != nil {
+				continue
+			}
+		case DoneLabelTag:
+			return nil
+		default:
+			return fmt.Errorf("invalid program counter %v", labelTag)
+		}
+	}
 }
 
 func AServer(ctx *distsys.MPCalContext, self distsys.TLAValue, constants Constants, net0 distsys.ArchetypeResourceHandle, netEnabled distsys.ArchetypeResourceHandle, fd0 distsys.ArchetypeResourceHandle) error {
-  var err0 error
-  // label tags
-  const (
-    InitLabelTag0 = iota
-    serverLoopLabelTag
-    serverRcvMsgLabelTag
-    serverSendMsgLabelTag
-    failLabelLabelTag
-    DoneLabelTag0
-  )
-  programCounter0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.NewTLANumber(InitLabelTag0)))
-  msg0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
-  _ = msg0
-  resp0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
-  _ = resp0
-  var fairnessCounter1 int = 0
-  var fairnessCounter2 int = 0
-  var fairnessCounter3 int = 0
-  
-  for {
-    if err0 != nil {
-      if err0 == distsys.ErrCriticalSectionAborted {
-        ctx.Abort()
-        err0 = nil
-      } else {
-        return err0
-      }
-    }
-    var labelTag0 distsys.TLAValue
-    labelTag0, err0 = ctx.Read(programCounter0, []distsys.TLAValue{})
-    if err0 != nil {
-      return err0
-    }
-    switch labelTag0.AsNumber() {
-    case InitLabelTag0:
-      err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverLoopLabelTag))
-      if err0 != nil {
-        continue
-      }
-    case serverLoopLabelTag:
-      if distsys.TLA_TRUE.AsBool() {
-        if constants.EXPLORE_FAIL.AsBool() {
-          fairnessCounterCurrent1 := fairnessCounter1
-          fairnessCounter1 = fairnessCounter1 + 1 % 2
-          switch fairnessCounterCurrent1 {
-          case 0:
-            // skip
-            err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverRcvMsgLabelTag))
-            if err0 != nil {
-              continue
-            }
-            err0 = ctx.Commit()
-            if err0 != nil {
-              continue
-            }
-          case 1:
-            err0 = ctx.Write(netEnabled, []distsys.TLAValue{self}, distsys.TLA_FALSE)
-            if err0 != nil {
-              continue
-            }
-            err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
-            if err0 != nil {
-              continue
-            }
-            err0 = ctx.Commit()
-            if err0 != nil {
-              continue
-            }
-          default:
-            panic("current branch of either matches no code paths!")
-          }
-          // no statements
-        } else {
-          err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverRcvMsgLabelTag))
-          if err0 != nil {
-            continue
-          }
-          err0 = ctx.Commit()
-          if err0 != nil {
-            continue
-          }
-        }
-        // no statements
-      } else {
-        err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
-        if err0 != nil {
-          continue
-        }
-        err0 = ctx.Commit()
-        if err0 != nil {
-          continue
-        }
-      }
-      // no statements
-    case serverRcvMsgLabelTag:
-      var exprRead13 distsys.TLAValue
-      exprRead13, err0 = ctx.Read(net0, []distsys.TLAValue{distsys.NewTLATuple(self, func() distsys.TLAValue {
-        return PROXY_REQ_MSG_TYP(constants)
-      }())})
-      if err0 != nil {
-        continue
-      }
-      err0 = ctx.Write(msg0, []distsys.TLAValue{}, exprRead13)
-      if err0 != nil {
-        continue
-      }
-      var condition12 distsys.TLAValue
-      condition12, err0 = ctx.Read(msg0, []distsys.TLAValue{})
-      if err0 != nil {
-        continue
-      }
-      var condition13 distsys.TLAValue
-      condition13, err0 = ctx.Read(msg0, []distsys.TLAValue{})
-      if err0 != nil {
-        continue
-      }
-      var condition14 distsys.TLAValue
-      condition14, err0 = ctx.Read(msg0, []distsys.TLAValue{})
-      if err0 != nil {
-        continue
-      }
-      if !distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition12.ApplyFunction(distsys.NewTLAString("to")), self), distsys.TLA_EqualsSymbol(condition13.ApplyFunction(distsys.NewTLAString("from")), func() distsys.TLAValue {
-        return ProxyID(constants)
-      }())), distsys.TLA_EqualsSymbol(condition14.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
-        return PROXY_REQ_MSG_TYP(constants)
-      }())).AsBool() {
-        err0 = fmt.Errorf("%w: ((((msg).to) = (self)) /\\ (((msg).from) = (ProxyID))) /\\ (((msg).typ) = (PROXY_REQ_MSG_TYP))", distsys.ErrAssertionFailed)
-        continue
-      }
-      if constants.EXPLORE_FAIL.AsBool() {
-        fairnessCounterCurrent2 := fairnessCounter2
-        fairnessCounter2 = fairnessCounter2 + 1 % 2
-        switch fairnessCounterCurrent2 {
-        case 0:
-          // skip
-          err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverSendMsgLabelTag))
-          if err0 != nil {
-            continue
-          }
-          err0 = ctx.Commit()
-          if err0 != nil {
-            continue
-          }
-        case 1:
-          err0 = ctx.Write(netEnabled, []distsys.TLAValue{self}, distsys.TLA_FALSE)
-          if err0 != nil {
-            continue
-          }
-          err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
-          if err0 != nil {
-            continue
-          }
-          err0 = ctx.Commit()
-          if err0 != nil {
-            continue
-          }
-        default:
-          panic("current branch of either matches no code paths!")
-        }
-        // no statements
-      } else {
-        err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverSendMsgLabelTag))
-        if err0 != nil {
-          continue
-        }
-        err0 = ctx.Commit()
-        if err0 != nil {
-          continue
-        }
-      }
-      // no statements
-    case serverSendMsgLabelTag:
-      var exprRead14 distsys.TLAValue
-      exprRead14, err0 = ctx.Read(msg0, []distsys.TLAValue{})
-      if err0 != nil {
-        continue
-      }
-      var exprRead15 distsys.TLAValue
-      exprRead15, err0 = ctx.Read(msg0, []distsys.TLAValue{})
-      if err0 != nil {
-        continue
-      }
-      err0 = ctx.Write(resp0, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
-        {distsys.NewTLAString("from"), self},
-        {distsys.NewTLAString("to"), exprRead14.ApplyFunction(distsys.NewTLAString("from"))},
-        {distsys.NewTLAString("body"), self},
-        {distsys.NewTLAString("id"), exprRead15.ApplyFunction(distsys.NewTLAString("id"))},
-        {distsys.NewTLAString("typ"), func() distsys.TLAValue {
-          return PROXY_RESP_MSG_TYP(constants)
-        }()},
-      }))
-      if err0 != nil {
-        continue
-      }
-      var exprRead16 distsys.TLAValue
-      exprRead16, err0 = ctx.Read(resp0, []distsys.TLAValue{})
-      if err0 != nil {
-        continue
-      }
-      var indexRead2 distsys.TLAValue
-      indexRead2, err0 = ctx.Read(resp0, []distsys.TLAValue{})
-      if err0 != nil {
-        continue
-      }
-      var indexRead3 distsys.TLAValue
-      indexRead3, err0 = ctx.Read(resp0, []distsys.TLAValue{})
-      if err0 != nil {
-        continue
-      }
-      err0 = ctx.Write(net0, []distsys.TLAValue{distsys.NewTLATuple(indexRead2.ApplyFunction(distsys.NewTLAString("to")), indexRead3.ApplyFunction(distsys.NewTLAString("typ")))}, exprRead16)
-      if err0 != nil {
-        continue
-      }
-      if constants.EXPLORE_FAIL.AsBool() {
-        fairnessCounterCurrent3 := fairnessCounter3
-        fairnessCounter3 = fairnessCounter3 + 1 % 2
-        switch fairnessCounterCurrent3 {
-        case 0:
-          // skip
-          err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverLoopLabelTag))
-          if err0 != nil {
-            continue
-          }
-          err0 = ctx.Commit()
-          if err0 != nil {
-            continue
-          }
-        case 1:
-          err0 = ctx.Write(netEnabled, []distsys.TLAValue{self}, distsys.TLA_FALSE)
-          if err0 != nil {
-            continue
-          }
-          err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
-          if err0 != nil {
-            continue
-          }
-          err0 = ctx.Commit()
-          if err0 != nil {
-            continue
-          }
-        default:
-          panic("current branch of either matches no code paths!")
-        }
-        // no statements
-      } else {
-        err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverLoopLabelTag))
-        if err0 != nil {
-          continue
-        }
-        err0 = ctx.Commit()
-        if err0 != nil {
-          continue
-        }
-      }
-      // no statements
-    case failLabelLabelTag:
-      err0 = ctx.Write(fd0, []distsys.TLAValue{self}, distsys.TLA_TRUE)
-      if err0 != nil {
-        continue
-      }
-      err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(DoneLabelTag0))
-      if err0 != nil {
-        continue
-      }
-      err0 = ctx.Commit()
-      if err0 != nil {
-        continue
-      }
-    case DoneLabelTag0:
-      return nil
-    default:
-      return fmt.Errorf("invalid program counter %v", labelTag0)
-    }
-  }
+	var err0 error
+	// label tags
+	const (
+		InitLabelTag0 = iota
+		serverLoopLabelTag
+		serverRcvMsgLabelTag
+		serverSendMsgLabelTag
+		failLabelLabelTag
+		DoneLabelTag0
+	)
+	programCounter0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.NewTLANumber(InitLabelTag0)))
+	msg0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+	_ = msg0
+	resp0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+	_ = resp0
+	var fairnessCounter1 int = 0
+	var fairnessCounter2 int = 0
+	var fairnessCounter3 int = 0
+
+	for {
+		if err0 != nil {
+			if err0 == distsys.ErrCriticalSectionAborted {
+				ctx.Abort()
+				err0 = nil
+			} else {
+				return err0
+			}
+		}
+		var labelTag0 distsys.TLAValue
+		labelTag0, err0 = ctx.Read(programCounter0, []distsys.TLAValue{})
+		if err0 != nil {
+			return err0
+		}
+		switch labelTag0.AsNumber() {
+		case InitLabelTag0:
+			err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverLoopLabelTag))
+			if err0 != nil {
+				continue
+			}
+		case serverLoopLabelTag:
+			if distsys.TLA_TRUE.AsBool() {
+				if constants.EXPLORE_FAIL.AsBool() {
+					fairnessCounterCurrent1 := fairnessCounter1
+					fairnessCounter1 = fairnessCounter1 + 1%2
+					switch fairnessCounterCurrent1 {
+					case 0:
+						// skip
+						err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverRcvMsgLabelTag))
+						if err0 != nil {
+							continue
+						}
+						err0 = ctx.Commit()
+						if err0 != nil {
+							continue
+						}
+					case 1:
+						err0 = ctx.Write(netEnabled, []distsys.TLAValue{self}, distsys.TLA_FALSE)
+						if err0 != nil {
+							continue
+						}
+						err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
+						if err0 != nil {
+							continue
+						}
+						err0 = ctx.Commit()
+						if err0 != nil {
+							continue
+						}
+					default:
+						panic("current branch of either matches no code paths!")
+					}
+					// no statements
+				} else {
+					err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverRcvMsgLabelTag))
+					if err0 != nil {
+						continue
+					}
+					err0 = ctx.Commit()
+					if err0 != nil {
+						continue
+					}
+				}
+				// no statements
+			} else {
+				err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
+				if err0 != nil {
+					continue
+				}
+				err0 = ctx.Commit()
+				if err0 != nil {
+					continue
+				}
+			}
+			// no statements
+		case serverRcvMsgLabelTag:
+			var exprRead13 distsys.TLAValue
+			exprRead13, err0 = ctx.Read(net0, []distsys.TLAValue{distsys.NewTLATuple(self, func() distsys.TLAValue {
+				return PROXY_REQ_MSG_TYP(constants)
+			}())})
+			if err0 != nil {
+				continue
+			}
+			err0 = ctx.Write(msg0, []distsys.TLAValue{}, exprRead13)
+			if err0 != nil {
+				continue
+			}
+			var condition12 distsys.TLAValue
+			condition12, err0 = ctx.Read(msg0, []distsys.TLAValue{})
+			if err0 != nil {
+				continue
+			}
+			var condition13 distsys.TLAValue
+			condition13, err0 = ctx.Read(msg0, []distsys.TLAValue{})
+			if err0 != nil {
+				continue
+			}
+			var condition14 distsys.TLAValue
+			condition14, err0 = ctx.Read(msg0, []distsys.TLAValue{})
+			if err0 != nil {
+				continue
+			}
+			if !distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition12.ApplyFunction(distsys.NewTLAString("to")), self), distsys.TLA_EqualsSymbol(condition13.ApplyFunction(distsys.NewTLAString("from")), func() distsys.TLAValue {
+				return ProxyID(constants)
+			}())), distsys.TLA_EqualsSymbol(condition14.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
+				return PROXY_REQ_MSG_TYP(constants)
+			}())).AsBool() {
+				err0 = fmt.Errorf("%w: ((((msg).to) = (self)) /\\ (((msg).from) = (ProxyID))) /\\ (((msg).typ) = (PROXY_REQ_MSG_TYP))", distsys.ErrAssertionFailed)
+				continue
+			}
+			if constants.EXPLORE_FAIL.AsBool() {
+				fairnessCounterCurrent2 := fairnessCounter2
+				fairnessCounter2 = fairnessCounter2 + 1%2
+				switch fairnessCounterCurrent2 {
+				case 0:
+					// skip
+					err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverSendMsgLabelTag))
+					if err0 != nil {
+						continue
+					}
+					err0 = ctx.Commit()
+					if err0 != nil {
+						continue
+					}
+				case 1:
+					err0 = ctx.Write(netEnabled, []distsys.TLAValue{self}, distsys.TLA_FALSE)
+					if err0 != nil {
+						continue
+					}
+					err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
+					if err0 != nil {
+						continue
+					}
+					err0 = ctx.Commit()
+					if err0 != nil {
+						continue
+					}
+				default:
+					panic("current branch of either matches no code paths!")
+				}
+				// no statements
+			} else {
+				err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverSendMsgLabelTag))
+				if err0 != nil {
+					continue
+				}
+				err0 = ctx.Commit()
+				if err0 != nil {
+					continue
+				}
+			}
+			// no statements
+		case serverSendMsgLabelTag:
+			var exprRead14 distsys.TLAValue
+			exprRead14, err0 = ctx.Read(msg0, []distsys.TLAValue{})
+			if err0 != nil {
+				continue
+			}
+			var exprRead15 distsys.TLAValue
+			exprRead15, err0 = ctx.Read(msg0, []distsys.TLAValue{})
+			if err0 != nil {
+				continue
+			}
+			err0 = ctx.Write(resp0, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
+				{distsys.NewTLAString("from"), self},
+				{distsys.NewTLAString("to"), exprRead14.ApplyFunction(distsys.NewTLAString("from"))},
+				{distsys.NewTLAString("body"), self},
+				{distsys.NewTLAString("id"), exprRead15.ApplyFunction(distsys.NewTLAString("id"))},
+				{distsys.NewTLAString("typ"), func() distsys.TLAValue {
+					return PROXY_RESP_MSG_TYP(constants)
+				}()},
+			}))
+			if err0 != nil {
+				continue
+			}
+			var exprRead16 distsys.TLAValue
+			exprRead16, err0 = ctx.Read(resp0, []distsys.TLAValue{})
+			if err0 != nil {
+				continue
+			}
+			var indexRead2 distsys.TLAValue
+			indexRead2, err0 = ctx.Read(resp0, []distsys.TLAValue{})
+			if err0 != nil {
+				continue
+			}
+			var indexRead3 distsys.TLAValue
+			indexRead3, err0 = ctx.Read(resp0, []distsys.TLAValue{})
+			if err0 != nil {
+				continue
+			}
+			err0 = ctx.Write(net0, []distsys.TLAValue{distsys.NewTLATuple(indexRead2.ApplyFunction(distsys.NewTLAString("to")), indexRead3.ApplyFunction(distsys.NewTLAString("typ")))}, exprRead16)
+			if err0 != nil {
+				continue
+			}
+			if constants.EXPLORE_FAIL.AsBool() {
+				fairnessCounterCurrent3 := fairnessCounter3
+				fairnessCounter3 = fairnessCounter3 + 1%2
+				switch fairnessCounterCurrent3 {
+				case 0:
+					// skip
+					err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverLoopLabelTag))
+					if err0 != nil {
+						continue
+					}
+					err0 = ctx.Commit()
+					if err0 != nil {
+						continue
+					}
+				case 1:
+					err0 = ctx.Write(netEnabled, []distsys.TLAValue{self}, distsys.TLA_FALSE)
+					if err0 != nil {
+						continue
+					}
+					err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
+					if err0 != nil {
+						continue
+					}
+					err0 = ctx.Commit()
+					if err0 != nil {
+						continue
+					}
+				default:
+					panic("current branch of either matches no code paths!")
+				}
+				// no statements
+			} else {
+				err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverLoopLabelTag))
+				if err0 != nil {
+					continue
+				}
+				err0 = ctx.Commit()
+				if err0 != nil {
+					continue
+				}
+			}
+			// no statements
+		case failLabelLabelTag:
+			err0 = ctx.Write(fd0, []distsys.TLAValue{self}, distsys.TLA_TRUE)
+			if err0 != nil {
+				continue
+			}
+			err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(DoneLabelTag0))
+			if err0 != nil {
+				continue
+			}
+			err0 = ctx.Commit()
+			if err0 != nil {
+				continue
+			}
+		case DoneLabelTag0:
+			return nil
+		default:
+			return fmt.Errorf("invalid program counter %v", labelTag0)
+		}
+	}
 }
 
 func AClient(ctx *distsys.MPCalContext, self distsys.TLAValue, constants Constants, net1 distsys.ArchetypeResourceHandle) error {
-  var err1 error
-  // label tags
-  const (
-    InitLabelTag1 = iota
-    clientLoopLabelTag
-    clientSendReqLabelTag
-    clientRcvRespLabelTag
-    DoneLabelTag1
-  )
-  programCounter1 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.NewTLANumber(InitLabelTag1)))
-  req := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
-  _ = req
-  resp1 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
-  _ = resp1
-  
-  for {
-    if err1 != nil {
-      if err1 == distsys.ErrCriticalSectionAborted {
-        ctx.Abort()
-        err1 = nil
-      } else {
-        return err1
-      }
-    }
-    var labelTag1 distsys.TLAValue
-    labelTag1, err1 = ctx.Read(programCounter1, []distsys.TLAValue{})
-    if err1 != nil {
-      return err1
-    }
-    switch labelTag1.AsNumber() {
-    case InitLabelTag1:
-      err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientLoopLabelTag))
-      if err1 != nil {
-        continue
-      }
-    case clientLoopLabelTag:
-      if distsys.TLA_TRUE.AsBool() {
-        err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientSendReqLabelTag))
-        if err1 != nil {
-          continue
-        }
-        err1 = ctx.Commit()
-        if err1 != nil {
-          continue
-        }
-      } else {
-        err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(DoneLabelTag1))
-        if err1 != nil {
-          continue
-        }
-        err1 = ctx.Commit()
-        if err1 != nil {
-          continue
-        }
-      }
-      // no statements
-    case clientSendReqLabelTag:
-      err1 = ctx.Write(req, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
-        {distsys.NewTLAString("from"), self},
-        {distsys.NewTLAString("to"), func() distsys.TLAValue {
-          return ProxyID(constants)
-        }()},
-        {distsys.NewTLAString("body"), self},
-        {distsys.NewTLAString("id"), distsys.NewTLANumber(0)},
-        {distsys.NewTLAString("typ"), func() distsys.TLAValue {
-          return REQ_MSG_TYP(constants)
-        }()},
-      }))
-      if err1 != nil {
-        continue
-      }
-      var exprRead17 distsys.TLAValue
-      exprRead17, err1 = ctx.Read(req, []distsys.TLAValue{})
-      if err1 != nil {
-        continue
-      }
-      var indexRead4 distsys.TLAValue
-      indexRead4, err1 = ctx.Read(req, []distsys.TLAValue{})
-      if err1 != nil {
-        continue
-      }
-      var indexRead5 distsys.TLAValue
-      indexRead5, err1 = ctx.Read(req, []distsys.TLAValue{})
-      if err1 != nil {
-        continue
-      }
-      err1 = ctx.Write(net1, []distsys.TLAValue{distsys.NewTLATuple(indexRead4.ApplyFunction(distsys.NewTLAString("to")), indexRead5.ApplyFunction(distsys.NewTLAString("typ")))}, exprRead17)
-      if err1 != nil {
-        continue
-      }
-      var toPrint distsys.TLAValue
-      toPrint, err1 = ctx.Read(req, []distsys.TLAValue{})
-      if err1 != nil {
-        continue
-      }
-      distsys.NewTLATuple(distsys.NewTLAString("CLIENT START"), toPrint).PCalPrint()
-      err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientRcvRespLabelTag))
-      if err1 != nil {
-        continue
-      }
-      err1 = ctx.Commit()
-      if err1 != nil {
-        continue
-      }
-    case clientRcvRespLabelTag:
-      var exprRead18 distsys.TLAValue
-      exprRead18, err1 = ctx.Read(net1, []distsys.TLAValue{distsys.NewTLATuple(self, func() distsys.TLAValue {
-        return RESP_MSG_TYP(constants)
-      }())})
-      if err1 != nil {
-        continue
-      }
-      err1 = ctx.Write(resp1, []distsys.TLAValue{}, exprRead18)
-      if err1 != nil {
-        continue
-      }
-      var condition15 distsys.TLAValue
-      condition15, err1 = ctx.Read(resp1, []distsys.TLAValue{})
-      if err1 != nil {
-        continue
-      }
-      var condition16 distsys.TLAValue
-      condition16, err1 = ctx.Read(resp1, []distsys.TLAValue{})
-      if err1 != nil {
-        continue
-      }
-      var condition17 distsys.TLAValue
-      condition17, err1 = ctx.Read(resp1, []distsys.TLAValue{})
-      if err1 != nil {
-        continue
-      }
-      if !distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition15.ApplyFunction(distsys.NewTLAString("to")), self), distsys.TLA_EqualsSymbol(condition16.ApplyFunction(distsys.NewTLAString("id")), distsys.NewTLANumber(0))), distsys.TLA_EqualsSymbol(condition17.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
-        return RESP_MSG_TYP(constants)
-      }())).AsBool() {
-        err1 = fmt.Errorf("%w: ((((resp).to) = (self)) /\\ (((resp).id) = (0))) /\\ (((resp).typ) = (RESP_MSG_TYP))", distsys.ErrAssertionFailed)
-        continue
-      }
-      var toPrint0 distsys.TLAValue
-      toPrint0, err1 = ctx.Read(resp1, []distsys.TLAValue{})
-      if err1 != nil {
-        continue
-      }
-      distsys.NewTLATuple(distsys.NewTLAString("CLIENT RESP"), toPrint0).PCalPrint()
-      err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientLoopLabelTag))
-      if err1 != nil {
-        continue
-      }
-      err1 = ctx.Commit()
-      if err1 != nil {
-        continue
-      }
-    case DoneLabelTag1:
-      return nil
-    default:
-      return fmt.Errorf("invalid program counter %v", labelTag1)
-    }
-  }
+	var err1 error
+	// label tags
+	const (
+		InitLabelTag1 = iota
+		clientLoopLabelTag
+		clientSendReqLabelTag
+		clientRcvRespLabelTag
+		DoneLabelTag1
+	)
+	programCounter1 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.NewTLANumber(InitLabelTag1)))
+	req := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+	_ = req
+	resp1 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+	_ = resp1
+
+	for {
+		if err1 != nil {
+			if err1 == distsys.ErrCriticalSectionAborted {
+				ctx.Abort()
+				err1 = nil
+			} else {
+				return err1
+			}
+		}
+		var labelTag1 distsys.TLAValue
+		labelTag1, err1 = ctx.Read(programCounter1, []distsys.TLAValue{})
+		if err1 != nil {
+			return err1
+		}
+		switch labelTag1.AsNumber() {
+		case InitLabelTag1:
+			err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientLoopLabelTag))
+			if err1 != nil {
+				continue
+			}
+		case clientLoopLabelTag:
+			if distsys.TLA_TRUE.AsBool() {
+				err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientSendReqLabelTag))
+				if err1 != nil {
+					continue
+				}
+				err1 = ctx.Commit()
+				if err1 != nil {
+					continue
+				}
+			} else {
+				err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(DoneLabelTag1))
+				if err1 != nil {
+					continue
+				}
+				err1 = ctx.Commit()
+				if err1 != nil {
+					continue
+				}
+			}
+			// no statements
+		case clientSendReqLabelTag:
+			err1 = ctx.Write(req, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
+				{distsys.NewTLAString("from"), self},
+				{distsys.NewTLAString("to"), func() distsys.TLAValue {
+					return ProxyID(constants)
+				}()},
+				{distsys.NewTLAString("body"), self},
+				{distsys.NewTLAString("id"), distsys.NewTLANumber(0)},
+				{distsys.NewTLAString("typ"), func() distsys.TLAValue {
+					return REQ_MSG_TYP(constants)
+				}()},
+			}))
+			if err1 != nil {
+				continue
+			}
+			var exprRead17 distsys.TLAValue
+			exprRead17, err1 = ctx.Read(req, []distsys.TLAValue{})
+			if err1 != nil {
+				continue
+			}
+			var indexRead4 distsys.TLAValue
+			indexRead4, err1 = ctx.Read(req, []distsys.TLAValue{})
+			if err1 != nil {
+				continue
+			}
+			var indexRead5 distsys.TLAValue
+			indexRead5, err1 = ctx.Read(req, []distsys.TLAValue{})
+			if err1 != nil {
+				continue
+			}
+			err1 = ctx.Write(net1, []distsys.TLAValue{distsys.NewTLATuple(indexRead4.ApplyFunction(distsys.NewTLAString("to")), indexRead5.ApplyFunction(distsys.NewTLAString("typ")))}, exprRead17)
+			if err1 != nil {
+				continue
+			}
+			var toPrint distsys.TLAValue
+			toPrint, err1 = ctx.Read(req, []distsys.TLAValue{})
+			if err1 != nil {
+				continue
+			}
+			distsys.NewTLATuple(distsys.NewTLAString("CLIENT START"), toPrint).PCalPrint()
+			err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientRcvRespLabelTag))
+			if err1 != nil {
+				continue
+			}
+			err1 = ctx.Commit()
+			if err1 != nil {
+				continue
+			}
+		case clientRcvRespLabelTag:
+			var exprRead18 distsys.TLAValue
+			exprRead18, err1 = ctx.Read(net1, []distsys.TLAValue{distsys.NewTLATuple(self, func() distsys.TLAValue {
+				return RESP_MSG_TYP(constants)
+			}())})
+			if err1 != nil {
+				continue
+			}
+			err1 = ctx.Write(resp1, []distsys.TLAValue{}, exprRead18)
+			if err1 != nil {
+				continue
+			}
+			var condition15 distsys.TLAValue
+			condition15, err1 = ctx.Read(resp1, []distsys.TLAValue{})
+			if err1 != nil {
+				continue
+			}
+			var condition16 distsys.TLAValue
+			condition16, err1 = ctx.Read(resp1, []distsys.TLAValue{})
+			if err1 != nil {
+				continue
+			}
+			var condition17 distsys.TLAValue
+			condition17, err1 = ctx.Read(resp1, []distsys.TLAValue{})
+			if err1 != nil {
+				continue
+			}
+			if !distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition15.ApplyFunction(distsys.NewTLAString("to")), self), distsys.TLA_EqualsSymbol(condition16.ApplyFunction(distsys.NewTLAString("id")), distsys.NewTLANumber(0))), distsys.TLA_EqualsSymbol(condition17.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
+				return RESP_MSG_TYP(constants)
+			}())).AsBool() {
+				err1 = fmt.Errorf("%w: ((((resp).to) = (self)) /\\ (((resp).id) = (0))) /\\ (((resp).typ) = (RESP_MSG_TYP))", distsys.ErrAssertionFailed)
+				continue
+			}
+			var toPrint0 distsys.TLAValue
+			toPrint0, err1 = ctx.Read(resp1, []distsys.TLAValue{})
+			if err1 != nil {
+				continue
+			}
+			distsys.NewTLATuple(distsys.NewTLAString("CLIENT RESP"), toPrint0).PCalPrint()
+			err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientLoopLabelTag))
+			if err1 != nil {
+				continue
+			}
+			err1 = ctx.Commit()
+			if err1 != nil {
+				continue
+			}
+		case DoneLabelTag1:
+			return nil
+		default:
+			return fmt.Errorf("invalid program counter %v", labelTag1)
+		}
+	}
 }

--- a/test/files/general/proxy_w_macro.tla.gotests/proxy_w_macro.go
+++ b/test/files/general/proxy_w_macro.tla.gotests/proxy_w_macro.go
@@ -1,0 +1,943 @@
+package proxy_w_macro
+
+import (
+  "github.com/UBC-NSS/pgo/distsys"
+  "fmt"
+)
+
+var _ = new(fmt.Stringer) // unconditionally prevent go compiler from reporting unused fmt import
+var _ = distsys.TLAValue{} // same, for distsys
+
+type Constants struct {
+  NUM_SERVERS distsys.TLAValue
+  NUM_CLIENTS distsys.TLAValue
+  EXPLORE_FAIL distsys.TLAValue
+  F distsys.TLAValue
+}
+
+func FAIL(constants Constants) distsys.TLAValue {
+  return distsys.NewTLANumber(100)
+}
+
+func NUM_NODES(constants Constants) distsys.TLAValue {
+  return distsys.TLA_PlusSymbol(distsys.TLA_PlusSymbol(constants.NUM_SERVERS, constants.NUM_CLIENTS), distsys.NewTLANumber(1))
+}
+
+func ProxyID(constants Constants) distsys.TLAValue {
+  return func() distsys.TLAValue {
+    return NUM_NODES(constants)
+  }()
+}
+
+func REQ_MSG_TYP(constants Constants) distsys.TLAValue {
+  return distsys.NewTLANumber(1)
+}
+
+func RESP_MSG_TYP(constants Constants) distsys.TLAValue {
+  return distsys.NewTLANumber(2)
+}
+
+func PROXY_REQ_MSG_TYP(constants Constants) distsys.TLAValue {
+  return distsys.NewTLANumber(3)
+}
+
+func PROXY_RESP_MSG_TYP(constants Constants) distsys.TLAValue {
+  return distsys.NewTLANumber(4)
+}
+
+func NODE_SET(constants Constants) distsys.TLAValue {
+  return distsys.TLA_DotDotSymbol(distsys.NewTLANumber(1), func() distsys.TLAValue {
+    return NUM_NODES(constants)
+  }())
+}
+
+func SERVER_SET(constants Constants) distsys.TLAValue {
+  return distsys.TLA_DotDotSymbol(distsys.NewTLANumber(1), constants.NUM_SERVERS)
+}
+
+func CLIENT_SET(constants Constants) distsys.TLAValue {
+  return distsys.TLA_DotDotSymbol(distsys.TLA_PlusSymbol(constants.NUM_SERVERS, distsys.NewTLANumber(1)), distsys.TLA_PlusSymbol(constants.NUM_SERVERS, constants.NUM_CLIENTS))
+}
+
+func MSG_TYP_SET(constants Constants) distsys.TLAValue {
+  return distsys.NewTLASet(func() distsys.TLAValue {
+    return REQ_MSG_TYP(constants)
+  }(), func() distsys.TLAValue {
+    return RESP_MSG_TYP(constants)
+  }(), func() distsys.TLAValue {
+    return PROXY_REQ_MSG_TYP(constants)
+  }(), func() distsys.TLAValue {
+    return PROXY_RESP_MSG_TYP(constants)
+  }())
+}
+
+
+func AProxy(ctx *distsys.MPCalContext, self distsys.TLAValue, constants Constants, net distsys.ArchetypeResourceHandle, fd distsys.ArchetypeResourceHandle) error {
+  var err error
+  // label tags
+  const (
+    InitLabelTag = iota
+    proxyLoopLabelTag
+    rcvMsgFromClientLabelTag
+    proxyMsgLabelTag
+    serversLoopLabelTag
+    proxySendMsgLabelTag
+    proxyRcvMsgLabelTag
+    sendMsgToClientLabelTag
+    DoneLabelTag
+  )
+  programCounter := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.NewTLANumber(InitLabelTag)))
+  msg := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+  _ = msg
+  proxyMsg0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+  _ = proxyMsg0
+  idx := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+  _ = idx
+  resp := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+  _ = resp
+  proxyResp := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+  _ = proxyResp
+  var fairnessCounter int = 0
+  var fairnessCounter0 int = 0
+  
+  for {
+    if err != nil {
+      if err == distsys.ErrCriticalSectionAborted {
+        ctx.Abort()
+        err = nil
+      } else {
+        return err
+      }
+    }
+    var labelTag distsys.TLAValue
+    labelTag, err = ctx.Read(programCounter, []distsys.TLAValue{})
+    if err != nil {
+      return err
+    }
+    switch labelTag.AsNumber() {
+    case InitLabelTag:
+      err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyLoopLabelTag))
+      if err != nil {
+        continue
+      }
+    case proxyLoopLabelTag:
+      if distsys.TLA_TRUE.AsBool() {
+        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(rcvMsgFromClientLabelTag))
+        if err != nil {
+          continue
+        }
+        err = ctx.Commit()
+        if err != nil {
+          continue
+        }
+      } else {
+        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(DoneLabelTag))
+        if err != nil {
+          continue
+        }
+        err = ctx.Commit()
+        if err != nil {
+          continue
+        }
+      }
+      // no statements
+    case rcvMsgFromClientLabelTag:
+      var exprRead distsys.TLAValue
+      exprRead, err = ctx.Read(net, []distsys.TLAValue{distsys.NewTLATuple(func() distsys.TLAValue {
+        return ProxyID(constants)
+      }(), func() distsys.TLAValue {
+        return REQ_MSG_TYP(constants)
+      }())})
+      if err != nil {
+        continue
+      }
+      err = ctx.Write(msg, []distsys.TLAValue{}, exprRead)
+      if err != nil {
+        continue
+      }
+      err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyMsgLabelTag))
+      if err != nil {
+        continue
+      }
+      err = ctx.Commit()
+      if err != nil {
+        continue
+      }
+    case proxyMsgLabelTag:
+      var condition distsys.TLAValue
+      condition, err = ctx.Read(msg, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      var condition0 distsys.TLAValue
+      condition0, err = ctx.Read(msg, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      if !distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition.ApplyFunction(distsys.NewTLAString("to")), func() distsys.TLAValue {
+        return ProxyID(constants)
+      }()), distsys.TLA_EqualsSymbol(condition0.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
+        return REQ_MSG_TYP(constants)
+      }())).AsBool() {
+        err = fmt.Errorf("%w: (((msg).to) = (ProxyID)) /\\ (((msg).typ) = (REQ_MSG_TYP))", distsys.ErrAssertionFailed)
+        continue
+      }
+      var exprRead0 distsys.TLAValue
+      exprRead0, err = ctx.Read(msg, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      var exprRead1 distsys.TLAValue
+      exprRead1, err = ctx.Read(msg, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      err = ctx.Write(proxyResp, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
+        {distsys.NewTLAString("from"), func() distsys.TLAValue {
+          return ProxyID(constants)
+        }()},
+        {distsys.NewTLAString("to"), exprRead0.ApplyFunction(distsys.NewTLAString("from"))},
+        {distsys.NewTLAString("body"), func() distsys.TLAValue {
+          return FAIL(constants)
+        }()},
+        {distsys.NewTLAString("id"), exprRead1.ApplyFunction(distsys.NewTLAString("id"))},
+        {distsys.NewTLAString("typ"), func() distsys.TLAValue {
+          return PROXY_RESP_MSG_TYP(constants)
+        }()},
+      }))
+      if err != nil {
+        continue
+      }
+      err = ctx.Write(idx, []distsys.TLAValue{}, distsys.NewTLANumber(1))
+      if err != nil {
+        continue
+      }
+      err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(serversLoopLabelTag))
+      if err != nil {
+        continue
+      }
+      err = ctx.Commit()
+      if err != nil {
+        continue
+      }
+    case serversLoopLabelTag:
+      var condition1 distsys.TLAValue
+      condition1, err = ctx.Read(idx, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      if distsys.TLA_LessThanOrEqualSymbol(condition1, constants.NUM_SERVERS).AsBool() {
+        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxySendMsgLabelTag))
+        if err != nil {
+          continue
+        }
+        err = ctx.Commit()
+        if err != nil {
+          continue
+        }
+      } else {
+        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(sendMsgToClientLabelTag))
+        if err != nil {
+          continue
+        }
+        err = ctx.Commit()
+        if err != nil {
+          continue
+        }
+      }
+      // no statements
+    case proxySendMsgLabelTag:
+      fairnessCounterCurrent := fairnessCounter
+      fairnessCounter = fairnessCounter + 1 % 2
+      switch fairnessCounterCurrent {
+      case 0:
+        var exprRead6 distsys.TLAValue
+        exprRead6, err = ctx.Read(idx, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        var exprRead7 distsys.TLAValue
+        exprRead7, err = ctx.Read(msg, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        var exprRead8 distsys.TLAValue
+        exprRead8, err = ctx.Read(msg, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        err = ctx.Write(proxyMsg0, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
+          {distsys.NewTLAString("from"), func() distsys.TLAValue {
+            return ProxyID(constants)
+          }()},
+          {distsys.NewTLAString("to"), exprRead6},
+          {distsys.NewTLAString("body"), exprRead7.ApplyFunction(distsys.NewTLAString("body"))},
+          {distsys.NewTLAString("id"), exprRead8.ApplyFunction(distsys.NewTLAString("id"))},
+          {distsys.NewTLAString("typ"), func() distsys.TLAValue {
+            return PROXY_REQ_MSG_TYP(constants)
+          }()},
+        }))
+        if err != nil {
+          continue
+        }
+        var exprRead9 distsys.TLAValue
+        exprRead9, err = ctx.Read(proxyMsg0, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        var indexRead1 distsys.TLAValue
+        indexRead1, err = ctx.Read(proxyMsg0, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        err = ctx.Write(net, []distsys.TLAValue{distsys.NewTLATuple(indexRead1.ApplyFunction(distsys.NewTLAString("to")), func() distsys.TLAValue {
+          return PROXY_REQ_MSG_TYP(constants)
+        }())}, exprRead9)
+        if err != nil {
+          continue
+        }
+        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyRcvMsgLabelTag))
+        if err != nil {
+          continue
+        }
+        err = ctx.Commit()
+        if err != nil {
+          continue
+        }
+      case 1:
+        var condition2 distsys.TLAValue
+        condition2, err = ctx.Read(idx, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        var condition3 distsys.TLAValue
+        condition3, err = ctx.Read(fd, []distsys.TLAValue{condition2})
+        if err != nil {
+          continue
+        }
+        if !condition3.AsBool() {
+          err = distsys.ErrCriticalSectionAborted
+          continue
+        }
+        var exprRead10 distsys.TLAValue
+        exprRead10, err = ctx.Read(idx, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        err = ctx.Write(idx, []distsys.TLAValue{}, distsys.TLA_PlusSymbol(exprRead10, distsys.NewTLANumber(1)))
+        if err != nil {
+          continue
+        }
+        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(serversLoopLabelTag))
+        if err != nil {
+          continue
+        }
+        err = ctx.Commit()
+        if err != nil {
+          continue
+        }
+      default:
+        panic("current branch of either matches no code paths!")
+      }
+      // no statements
+    case proxyRcvMsgLabelTag:
+      fairnessCounterCurrent0 := fairnessCounter0
+      fairnessCounter0 = fairnessCounter0 + 1 % 2
+      switch fairnessCounterCurrent0 {
+      case 0:
+        var exprRead11 distsys.TLAValue
+        exprRead11, err = ctx.Read(net, []distsys.TLAValue{distsys.NewTLATuple(func() distsys.TLAValue {
+          return ProxyID(constants)
+        }(), func() distsys.TLAValue {
+          return PROXY_RESP_MSG_TYP(constants)
+        }())})
+        if err != nil {
+          continue
+        }
+        err = ctx.Write(proxyResp, []distsys.TLAValue{}, exprRead11)
+        if err != nil {
+          continue
+        }
+        var condition4 distsys.TLAValue
+        condition4, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        var condition5 distsys.TLAValue
+        condition5, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        var condition6 distsys.TLAValue
+        condition6, err = ctx.Read(idx, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        var condition7 distsys.TLAValue
+        condition7, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        var condition8 distsys.TLAValue
+        condition8, err = ctx.Read(msg, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        var condition9 distsys.TLAValue
+        condition9, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        if !distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition4.ApplyFunction(distsys.NewTLAString("to")), func() distsys.TLAValue {
+          return ProxyID(constants)
+        }()), distsys.TLA_EqualsSymbol(condition5.ApplyFunction(distsys.NewTLAString("from")), condition6)), distsys.TLA_EqualsSymbol(condition7.ApplyFunction(distsys.NewTLAString("id")), condition8.ApplyFunction(distsys.NewTLAString("id")))), distsys.TLA_EqualsSymbol(condition9.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
+          return PROXY_RESP_MSG_TYP(constants)
+        }())).AsBool() {
+          err = fmt.Errorf("%w: (((((proxyResp).to) = (ProxyID)) /\\ (((proxyResp).from) = (idx))) /\\ (((proxyResp).id) = ((msg).id))) /\\ (((proxyResp).typ) = (PROXY_RESP_MSG_TYP))", distsys.ErrAssertionFailed)
+          continue
+        }
+        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(sendMsgToClientLabelTag))
+        if err != nil {
+          continue
+        }
+        err = ctx.Commit()
+        if err != nil {
+          continue
+        }
+      case 1:
+        var condition10 distsys.TLAValue
+        condition10, err = ctx.Read(idx, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        var condition11 distsys.TLAValue
+        condition11, err = ctx.Read(fd, []distsys.TLAValue{condition10})
+        if err != nil {
+          continue
+        }
+        if !condition11.AsBool() {
+          err = distsys.ErrCriticalSectionAborted
+          continue
+        }
+        var exprRead12 distsys.TLAValue
+        exprRead12, err = ctx.Read(idx, []distsys.TLAValue{})
+        if err != nil {
+          continue
+        }
+        err = ctx.Write(idx, []distsys.TLAValue{}, distsys.TLA_PlusSymbol(exprRead12, distsys.NewTLANumber(1)))
+        if err != nil {
+          continue
+        }
+        err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(serversLoopLabelTag))
+        if err != nil {
+          continue
+        }
+        err = ctx.Commit()
+        if err != nil {
+          continue
+        }
+      default:
+        panic("current branch of either matches no code paths!")
+      }
+      // no statements
+    case sendMsgToClientLabelTag:
+      var exprRead2 distsys.TLAValue
+      exprRead2, err = ctx.Read(msg, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      var exprRead3 distsys.TLAValue
+      exprRead3, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      var exprRead4 distsys.TLAValue
+      exprRead4, err = ctx.Read(proxyResp, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      err = ctx.Write(resp, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
+        {distsys.NewTLAString("from"), func() distsys.TLAValue {
+          return ProxyID(constants)
+        }()},
+        {distsys.NewTLAString("to"), exprRead2.ApplyFunction(distsys.NewTLAString("from"))},
+        {distsys.NewTLAString("body"), exprRead3.ApplyFunction(distsys.NewTLAString("body"))},
+        {distsys.NewTLAString("id"), exprRead4.ApplyFunction(distsys.NewTLAString("id"))},
+        {distsys.NewTLAString("typ"), func() distsys.TLAValue {
+          return RESP_MSG_TYP(constants)
+        }()},
+      }))
+      if err != nil {
+        continue
+      }
+      var exprRead5 distsys.TLAValue
+      exprRead5, err = ctx.Read(resp, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      var indexRead distsys.TLAValue
+      indexRead, err = ctx.Read(resp, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      var indexRead0 distsys.TLAValue
+      indexRead0, err = ctx.Read(resp, []distsys.TLAValue{})
+      if err != nil {
+        continue
+      }
+      err = ctx.Write(net, []distsys.TLAValue{distsys.NewTLATuple(indexRead.ApplyFunction(distsys.NewTLAString("to")), indexRead0.ApplyFunction(distsys.NewTLAString("typ")))}, exprRead5)
+      if err != nil {
+        continue
+      }
+      err = ctx.Write(programCounter, []distsys.TLAValue{}, distsys.NewTLANumber(proxyLoopLabelTag))
+      if err != nil {
+        continue
+      }
+      err = ctx.Commit()
+      if err != nil {
+        continue
+      }
+    case DoneLabelTag:
+      return nil
+    default:
+      return fmt.Errorf("invalid program counter %v", labelTag)
+    }
+  }
+}
+
+func AServer(ctx *distsys.MPCalContext, self distsys.TLAValue, constants Constants, net0 distsys.ArchetypeResourceHandle, netEnabled distsys.ArchetypeResourceHandle, fd0 distsys.ArchetypeResourceHandle) error {
+  var err0 error
+  // label tags
+  const (
+    InitLabelTag0 = iota
+    serverLoopLabelTag
+    serverRcvMsgLabelTag
+    serverSendMsgLabelTag
+    failLabelLabelTag
+    DoneLabelTag0
+  )
+  programCounter0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.NewTLANumber(InitLabelTag0)))
+  msg0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+  _ = msg0
+  resp0 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+  _ = resp0
+  var fairnessCounter1 int = 0
+  var fairnessCounter2 int = 0
+  var fairnessCounter3 int = 0
+  
+  for {
+    if err0 != nil {
+      if err0 == distsys.ErrCriticalSectionAborted {
+        ctx.Abort()
+        err0 = nil
+      } else {
+        return err0
+      }
+    }
+    var labelTag0 distsys.TLAValue
+    labelTag0, err0 = ctx.Read(programCounter0, []distsys.TLAValue{})
+    if err0 != nil {
+      return err0
+    }
+    switch labelTag0.AsNumber() {
+    case InitLabelTag0:
+      err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverLoopLabelTag))
+      if err0 != nil {
+        continue
+      }
+    case serverLoopLabelTag:
+      if distsys.TLA_TRUE.AsBool() {
+        if constants.EXPLORE_FAIL.AsBool() {
+          fairnessCounterCurrent1 := fairnessCounter1
+          fairnessCounter1 = fairnessCounter1 + 1 % 2
+          switch fairnessCounterCurrent1 {
+          case 0:
+            // skip
+            err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverRcvMsgLabelTag))
+            if err0 != nil {
+              continue
+            }
+            err0 = ctx.Commit()
+            if err0 != nil {
+              continue
+            }
+          case 1:
+            err0 = ctx.Write(netEnabled, []distsys.TLAValue{self}, distsys.TLA_FALSE)
+            if err0 != nil {
+              continue
+            }
+            err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
+            if err0 != nil {
+              continue
+            }
+            err0 = ctx.Commit()
+            if err0 != nil {
+              continue
+            }
+          default:
+            panic("current branch of either matches no code paths!")
+          }
+          // no statements
+        } else {
+          err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverRcvMsgLabelTag))
+          if err0 != nil {
+            continue
+          }
+          err0 = ctx.Commit()
+          if err0 != nil {
+            continue
+          }
+        }
+        // no statements
+      } else {
+        err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
+        if err0 != nil {
+          continue
+        }
+        err0 = ctx.Commit()
+        if err0 != nil {
+          continue
+        }
+      }
+      // no statements
+    case serverRcvMsgLabelTag:
+      var exprRead13 distsys.TLAValue
+      exprRead13, err0 = ctx.Read(net0, []distsys.TLAValue{distsys.NewTLATuple(self, func() distsys.TLAValue {
+        return PROXY_REQ_MSG_TYP(constants)
+      }())})
+      if err0 != nil {
+        continue
+      }
+      err0 = ctx.Write(msg0, []distsys.TLAValue{}, exprRead13)
+      if err0 != nil {
+        continue
+      }
+      var condition12 distsys.TLAValue
+      condition12, err0 = ctx.Read(msg0, []distsys.TLAValue{})
+      if err0 != nil {
+        continue
+      }
+      var condition13 distsys.TLAValue
+      condition13, err0 = ctx.Read(msg0, []distsys.TLAValue{})
+      if err0 != nil {
+        continue
+      }
+      var condition14 distsys.TLAValue
+      condition14, err0 = ctx.Read(msg0, []distsys.TLAValue{})
+      if err0 != nil {
+        continue
+      }
+      if !distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition12.ApplyFunction(distsys.NewTLAString("to")), self), distsys.TLA_EqualsSymbol(condition13.ApplyFunction(distsys.NewTLAString("from")), func() distsys.TLAValue {
+        return ProxyID(constants)
+      }())), distsys.TLA_EqualsSymbol(condition14.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
+        return PROXY_REQ_MSG_TYP(constants)
+      }())).AsBool() {
+        err0 = fmt.Errorf("%w: ((((msg).to) = (self)) /\\ (((msg).from) = (ProxyID))) /\\ (((msg).typ) = (PROXY_REQ_MSG_TYP))", distsys.ErrAssertionFailed)
+        continue
+      }
+      if constants.EXPLORE_FAIL.AsBool() {
+        fairnessCounterCurrent2 := fairnessCounter2
+        fairnessCounter2 = fairnessCounter2 + 1 % 2
+        switch fairnessCounterCurrent2 {
+        case 0:
+          // skip
+          err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverSendMsgLabelTag))
+          if err0 != nil {
+            continue
+          }
+          err0 = ctx.Commit()
+          if err0 != nil {
+            continue
+          }
+        case 1:
+          err0 = ctx.Write(netEnabled, []distsys.TLAValue{self}, distsys.TLA_FALSE)
+          if err0 != nil {
+            continue
+          }
+          err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
+          if err0 != nil {
+            continue
+          }
+          err0 = ctx.Commit()
+          if err0 != nil {
+            continue
+          }
+        default:
+          panic("current branch of either matches no code paths!")
+        }
+        // no statements
+      } else {
+        err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverSendMsgLabelTag))
+        if err0 != nil {
+          continue
+        }
+        err0 = ctx.Commit()
+        if err0 != nil {
+          continue
+        }
+      }
+      // no statements
+    case serverSendMsgLabelTag:
+      var exprRead14 distsys.TLAValue
+      exprRead14, err0 = ctx.Read(msg0, []distsys.TLAValue{})
+      if err0 != nil {
+        continue
+      }
+      var exprRead15 distsys.TLAValue
+      exprRead15, err0 = ctx.Read(msg0, []distsys.TLAValue{})
+      if err0 != nil {
+        continue
+      }
+      err0 = ctx.Write(resp0, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
+        {distsys.NewTLAString("from"), self},
+        {distsys.NewTLAString("to"), exprRead14.ApplyFunction(distsys.NewTLAString("from"))},
+        {distsys.NewTLAString("body"), self},
+        {distsys.NewTLAString("id"), exprRead15.ApplyFunction(distsys.NewTLAString("id"))},
+        {distsys.NewTLAString("typ"), func() distsys.TLAValue {
+          return PROXY_RESP_MSG_TYP(constants)
+        }()},
+      }))
+      if err0 != nil {
+        continue
+      }
+      var exprRead16 distsys.TLAValue
+      exprRead16, err0 = ctx.Read(resp0, []distsys.TLAValue{})
+      if err0 != nil {
+        continue
+      }
+      var indexRead2 distsys.TLAValue
+      indexRead2, err0 = ctx.Read(resp0, []distsys.TLAValue{})
+      if err0 != nil {
+        continue
+      }
+      var indexRead3 distsys.TLAValue
+      indexRead3, err0 = ctx.Read(resp0, []distsys.TLAValue{})
+      if err0 != nil {
+        continue
+      }
+      err0 = ctx.Write(net0, []distsys.TLAValue{distsys.NewTLATuple(indexRead2.ApplyFunction(distsys.NewTLAString("to")), indexRead3.ApplyFunction(distsys.NewTLAString("typ")))}, exprRead16)
+      if err0 != nil {
+        continue
+      }
+      if constants.EXPLORE_FAIL.AsBool() {
+        fairnessCounterCurrent3 := fairnessCounter3
+        fairnessCounter3 = fairnessCounter3 + 1 % 2
+        switch fairnessCounterCurrent3 {
+        case 0:
+          // skip
+          err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverLoopLabelTag))
+          if err0 != nil {
+            continue
+          }
+          err0 = ctx.Commit()
+          if err0 != nil {
+            continue
+          }
+        case 1:
+          err0 = ctx.Write(netEnabled, []distsys.TLAValue{self}, distsys.TLA_FALSE)
+          if err0 != nil {
+            continue
+          }
+          err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(failLabelLabelTag))
+          if err0 != nil {
+            continue
+          }
+          err0 = ctx.Commit()
+          if err0 != nil {
+            continue
+          }
+        default:
+          panic("current branch of either matches no code paths!")
+        }
+        // no statements
+      } else {
+        err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(serverLoopLabelTag))
+        if err0 != nil {
+          continue
+        }
+        err0 = ctx.Commit()
+        if err0 != nil {
+          continue
+        }
+      }
+      // no statements
+    case failLabelLabelTag:
+      err0 = ctx.Write(fd0, []distsys.TLAValue{self}, distsys.TLA_TRUE)
+      if err0 != nil {
+        continue
+      }
+      err0 = ctx.Write(programCounter0, []distsys.TLAValue{}, distsys.NewTLANumber(DoneLabelTag0))
+      if err0 != nil {
+        continue
+      }
+      err0 = ctx.Commit()
+      if err0 != nil {
+        continue
+      }
+    case DoneLabelTag0:
+      return nil
+    default:
+      return fmt.Errorf("invalid program counter %v", labelTag0)
+    }
+  }
+}
+
+func AClient(ctx *distsys.MPCalContext, self distsys.TLAValue, constants Constants, net1 distsys.ArchetypeResourceHandle) error {
+  var err1 error
+  // label tags
+  const (
+    InitLabelTag1 = iota
+    clientLoopLabelTag
+    clientSendReqLabelTag
+    clientRcvRespLabelTag
+    DoneLabelTag1
+  )
+  programCounter1 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.NewTLANumber(InitLabelTag1)))
+  req := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+  _ = req
+  resp1 := ctx.EnsureArchetypeResourceByPosition(distsys.LocalArchetypeResourceMaker(distsys.TLAValue{}))
+  _ = resp1
+  
+  for {
+    if err1 != nil {
+      if err1 == distsys.ErrCriticalSectionAborted {
+        ctx.Abort()
+        err1 = nil
+      } else {
+        return err1
+      }
+    }
+    var labelTag1 distsys.TLAValue
+    labelTag1, err1 = ctx.Read(programCounter1, []distsys.TLAValue{})
+    if err1 != nil {
+      return err1
+    }
+    switch labelTag1.AsNumber() {
+    case InitLabelTag1:
+      err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientLoopLabelTag))
+      if err1 != nil {
+        continue
+      }
+    case clientLoopLabelTag:
+      if distsys.TLA_TRUE.AsBool() {
+        err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientSendReqLabelTag))
+        if err1 != nil {
+          continue
+        }
+        err1 = ctx.Commit()
+        if err1 != nil {
+          continue
+        }
+      } else {
+        err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(DoneLabelTag1))
+        if err1 != nil {
+          continue
+        }
+        err1 = ctx.Commit()
+        if err1 != nil {
+          continue
+        }
+      }
+      // no statements
+    case clientSendReqLabelTag:
+      err1 = ctx.Write(req, []distsys.TLAValue{}, distsys.NewTLARecord([]distsys.TLARecordField{
+        {distsys.NewTLAString("from"), self},
+        {distsys.NewTLAString("to"), func() distsys.TLAValue {
+          return ProxyID(constants)
+        }()},
+        {distsys.NewTLAString("body"), self},
+        {distsys.NewTLAString("id"), distsys.NewTLANumber(0)},
+        {distsys.NewTLAString("typ"), func() distsys.TLAValue {
+          return REQ_MSG_TYP(constants)
+        }()},
+      }))
+      if err1 != nil {
+        continue
+      }
+      var exprRead17 distsys.TLAValue
+      exprRead17, err1 = ctx.Read(req, []distsys.TLAValue{})
+      if err1 != nil {
+        continue
+      }
+      var indexRead4 distsys.TLAValue
+      indexRead4, err1 = ctx.Read(req, []distsys.TLAValue{})
+      if err1 != nil {
+        continue
+      }
+      var indexRead5 distsys.TLAValue
+      indexRead5, err1 = ctx.Read(req, []distsys.TLAValue{})
+      if err1 != nil {
+        continue
+      }
+      err1 = ctx.Write(net1, []distsys.TLAValue{distsys.NewTLATuple(indexRead4.ApplyFunction(distsys.NewTLAString("to")), indexRead5.ApplyFunction(distsys.NewTLAString("typ")))}, exprRead17)
+      if err1 != nil {
+        continue
+      }
+      var toPrint distsys.TLAValue
+      toPrint, err1 = ctx.Read(req, []distsys.TLAValue{})
+      if err1 != nil {
+        continue
+      }
+      distsys.NewTLATuple(distsys.NewTLAString("CLIENT START"), toPrint).PCalPrint()
+      err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientRcvRespLabelTag))
+      if err1 != nil {
+        continue
+      }
+      err1 = ctx.Commit()
+      if err1 != nil {
+        continue
+      }
+    case clientRcvRespLabelTag:
+      var exprRead18 distsys.TLAValue
+      exprRead18, err1 = ctx.Read(net1, []distsys.TLAValue{distsys.NewTLATuple(self, func() distsys.TLAValue {
+        return RESP_MSG_TYP(constants)
+      }())})
+      if err1 != nil {
+        continue
+      }
+      err1 = ctx.Write(resp1, []distsys.TLAValue{}, exprRead18)
+      if err1 != nil {
+        continue
+      }
+      var condition15 distsys.TLAValue
+      condition15, err1 = ctx.Read(resp1, []distsys.TLAValue{})
+      if err1 != nil {
+        continue
+      }
+      var condition16 distsys.TLAValue
+      condition16, err1 = ctx.Read(resp1, []distsys.TLAValue{})
+      if err1 != nil {
+        continue
+      }
+      var condition17 distsys.TLAValue
+      condition17, err1 = ctx.Read(resp1, []distsys.TLAValue{})
+      if err1 != nil {
+        continue
+      }
+      if !distsys.TLA_LogicalAndSymbol(distsys.TLA_LogicalAndSymbol(distsys.TLA_EqualsSymbol(condition15.ApplyFunction(distsys.NewTLAString("to")), self), distsys.TLA_EqualsSymbol(condition16.ApplyFunction(distsys.NewTLAString("id")), distsys.NewTLANumber(0))), distsys.TLA_EqualsSymbol(condition17.ApplyFunction(distsys.NewTLAString("typ")), func() distsys.TLAValue {
+        return RESP_MSG_TYP(constants)
+      }())).AsBool() {
+        err1 = fmt.Errorf("%w: ((((resp).to) = (self)) /\\ (((resp).id) = (0))) /\\ (((resp).typ) = (RESP_MSG_TYP))", distsys.ErrAssertionFailed)
+        continue
+      }
+      var toPrint0 distsys.TLAValue
+      toPrint0, err1 = ctx.Read(resp1, []distsys.TLAValue{})
+      if err1 != nil {
+        continue
+      }
+      distsys.NewTLATuple(distsys.NewTLAString("CLIENT RESP"), toPrint0).PCalPrint()
+      err1 = ctx.Write(programCounter1, []distsys.TLAValue{}, distsys.NewTLANumber(clientLoopLabelTag))
+      if err1 != nil {
+        continue
+      }
+      err1 = ctx.Commit()
+      if err1 != nil {
+        continue
+      }
+    case DoneLabelTag1:
+      return nil
+    default:
+      return fmt.Errorf("invalid program counter %v", labelTag1)
+    }
+  }
+}

--- a/test/files/general/replicated_kv.tla.expectpcal
+++ b/test/files/general/replicated_kv.tla.expectpcal
@@ -643,8 +643,6 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
       mapping replicasNetwork[_] via FIFOChannel;
 }
 
-
-
 \* BEGIN PLUSCAL TRANSLATION
 --algorithm ReplicatedKV {
   variables replicasNetwork = [id \in ReplicaSet |-> <<>>]; allClients = (((GetSet) \union (PutSet)) \union (DisconnectSet)) \union (NullSet); clientMailboxes = [id \in allClients |-> <<>>]; cid = 0; out = 0; clocks = [c \in ClientSet |-> 0];
@@ -1022,7 +1020,6 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
 }
 
 \* END PLUSCAL TRANSLATION
-
 
 
 ***************************************************************************)

--- a/test/files/pcalgen/BadPCalMarkerPlacementBeginMissing.tla
+++ b/test/files/pcalgen/BadPCalMarkerPlacementBeginMissing.tla
@@ -1,0 +1,16 @@
+---- MODULE BadPCalMarkerPlacementBeginMissing ----
+EXTENDS TLC
+
+(* --mpcal BadPCalMarkerPlacementBeginMissing {
+process (Nothing = 0) {
+    lbl: skip;
+}
+} *)
+
+\* +3 because it's not worth the pain of trying to get the error to _not_ point to END vs. the \* part of the comment
+\*:: expectedError+3: PCalTagsError
+\* END PLUSCAL TRANSLATION
+
+\* BEGIN TRANSLATION
+
+====

--- a/test/files/pcalgen/BadPCalMarkerPlacementBothMissing.tla
+++ b/test/files/pcalgen/BadPCalMarkerPlacementBothMissing.tla
@@ -1,0 +1,12 @@
+---- MODULE BadPCalMarkerPlacementBothMissing ----
+EXTENDS TLC
+
+(* --mpcal BadPCalMarkerPlacementBothMissing {
+process (Nothing = 0) {
+    lbl: skip;
+}
+} *)
+
+\* BEGIN TRANSLATION
+
+==== \*:: expectedError: PCalTagsError

--- a/test/files/pcalgen/BadPCalMarkerPlacementEndMissing.tla
+++ b/test/files/pcalgen/BadPCalMarkerPlacementEndMissing.tla
@@ -1,0 +1,14 @@
+---- MODULE BadPCalMarkerPlacementEndMissing ----
+EXTENDS TLC
+
+(* --mpcal BadPCalMarkerPlacementEndMissing {
+process (Nothing = 0) {
+    lbl: skip;
+}
+} *)
+
+\* BEGIN PLUSCAL TRANSLATION
+
+\* BEGIN TRANSLATION
+
+==== \*:: expectedError: PCalTagsError

--- a/test/files/pcalgen/BadPCalMarkerPlacementSwapped.tla
+++ b/test/files/pcalgen/BadPCalMarkerPlacementSwapped.tla
@@ -1,0 +1,17 @@
+---- MODULE BadPCalMarkerPlacementSwapped ----
+EXTENDS TLC
+
+(* --mpcal BadPCalMarkerPlacementSwapped {
+process (Nothing = 0) {
+    lbl: skip;
+}
+} *)
+
+\* +3 because it's not worth the pain of trying to get the error to _not_ point to END vs. the \* part of the comment
+\*:: expectedError+3: PCalTagsError
+\* END PLUSCAL TRANSLATION
+\* BEGIN PLUSCAL TRANSLATION
+
+\* BEGIN TRANSLATION
+
+====

--- a/test/pgo/util/TLAExprInterpreterTests.scala
+++ b/test/pgo/util/TLAExprInterpreterTests.scala
@@ -6,7 +6,7 @@ import pgo.model.SourceLocation
 import pgo.model.tla.BuiltinModules
 import pgo.parser.TLAParser
 import pgo.trans.MPCalGoCodegenPass
-import pgo.util.TLAExprInterpreter.{TLAValue, TLAValueNumber}
+import pgo.util.TLAExprInterpreter.{TLAValue, TLAValueBool, TLAValueNumber}
 
 class TLAExprInterpreterTests extends AnyFunSuite {
   private lazy val builtinOps = BuiltinModules.builtinModules.values.view
@@ -40,4 +40,7 @@ class TLAExprInterpreterTests extends AnyFunSuite {
     s"""[foo |-> 1]["bar"]"""
   }
 
+  checkPass("existential avoids errors when a set is empty") {
+    s"""\\E <<w, zk>> \\in {"}nWO"}, juAOg \\in {} : w""" -> TLAValueBool(false)
+  }
 }


### PR DESCRIPTION
- Replace janky regex trickery with a tiny parser system, so we can report pretty positional errors if people mess up tag placement
- Add tests for most cases of this now-real error
- Notice that multiple test cases were previously hiding wrong behaviour (PGo just not writing its PCal output sometimes, without telling anyone... eep!), and this this change fixed them
- Additionally, this change removes a little bit of newline padding that would, if PGo were run repeatedly in the same file in pcalgen mode (an expected situation), slowly add more and more newlines to the TLA+ file.