### PR TITLE
fix staticcheck errors

### DIFF
--- a/distsys/mpcalctx.go
+++ b/distsys/mpcalctx.go
@@ -540,18 +540,17 @@ func (ctx *MPCalContext) Run() error {
 		case nil: // everything is fine; carry on
 		case ErrCriticalSectionAborted:
 			ctx.abort()
+			// we want to keep the invariant that always err is nil after the error
+			// handling in the beginning of the loop. It's easier to read the code and
+			// resaon about it with this invariant.
+			//nolint:ineffassign
+			err = nil
 		case ErrDone: // signals that we're done; quit successfully
 			return nil
 		default:
 			// some other error; return it to caller, we probably crashed
 			return err
 		}
-
-		//nolint:ineffassign
-		// we want to keep the invariant that always err is nil after the error
-		// handling in the beginning of the loop. Easier to read the code and
-		// resaon about it with this invariant.
-		err = nil
 
 		// poll the done channel for Close calls.
 		// this should execute "regularly", since all archetype label implementations are non-blocking

--- a/distsys/mpcalctx.go
+++ b/distsys/mpcalctx.go
@@ -23,7 +23,7 @@ var ErrCriticalSectionAborted = errors.New("MPCal critical section aborted")
 var ErrContextClosed = errors.New("MPCal context closed")
 
 // ErrDone exists only to be returned by archetype code implementing the Done label
-var ErrDone = errors.New("A pseudo-error to indicate an archetype has terminated execution normally")
+var ErrDone = errors.New("a pseudo-error to indicate an archetype has terminated execution normally")
 
 // ErrProcedureFallthrough indicated an archetype reached the Error label, and crashed.
 var ErrProcedureFallthrough = errors.New("control has reached the end of a procedure body without reaching a return")
@@ -408,7 +408,7 @@ func (ctx *MPCalContext) ensureArchetypeResource(name string, maker ArchetypeRes
 	handle := ArchetypeResourceHandle(name)
 	// this case accounts for the case where the desired resource already exists
 	if res, ok := ctx.resources[handle]; ok {
-		maker.Configure(res.(ArchetypeResource))
+		maker.Configure(res)
 	} else {
 		res := maker.Make()
 		maker.Configure(res)

--- a/distsys/mpcalctx.go
+++ b/distsys/mpcalctx.go
@@ -540,13 +540,18 @@ func (ctx *MPCalContext) Run() error {
 		case nil: // everything is fine; carry on
 		case ErrCriticalSectionAborted:
 			ctx.abort()
-			err = nil
 		case ErrDone: // signals that we're done; quit successfully
 			return nil
 		default:
 			// some other error; return it to caller, we probably crashed
 			return err
 		}
+
+		//nolint:ineffassign
+		// we want to keep the invariant that always err is nil after the error
+		// handling in the beginning of the loop. Easier to read the code and
+		// resaon about it with this invariant.
+		err = nil
 
 		// poll the done channel for Close calls.
 		// this should execute "regularly", since all archetype label implementations are non-blocking

--- a/distsys/resources/fd.go
+++ b/distsys/resources/fd.go
@@ -278,10 +278,11 @@ func (res *singleFailureDetector) ensureClient() error {
 func (res *singleFailureDetector) mainLoop() {
 	res.done = make(chan struct{})
 	res.ticker = time.NewTicker(res.pullInterval)
+loop:
 	for range res.ticker.C {
 		select {
 		case <-res.done:
-			break
+			break loop
 		default:
 		}
 


### PR DESCRIPTION
This PR fixes the following [staticcheck](https://staticcheck.io/) errors:
```
/Users/shayan/src/github.com/UBC-NSS/pgo/distsys/mpcalctx.go
  (26, 15)   ST1005  error strings should not be capitalized
  (411, 19)  S1040   type assertion to the same type: res already has type ArchetypeResource

/Users/shayan/src/github.com/UBC-NSS/pgo/distsys/resources/fd.go
  (284, 4)  SA4011  ineffective break statement. Did you mean to break out of the outer loop?

/Users/shayan/src/github.com/UBC-NSS/pgo/distsys/resources/tcpmailboxes.go
  (204, 4)  SA4006  this value of doContinue is never used
  (225, 4)  SA4006  this value of doContinue is never used
```