### PR TITLE
GCounter resource fixes

### DIFF
--- a/distsys/resources/gcounter.go
+++ b/distsys/resources/gcounter.go
@@ -159,9 +159,6 @@ func (res *GCounter) WriteValue(value tla.TLAValue) error {
 	defer res.state.stateMu.Unlock()
 
 	state := res.state
-	if !value.IsNumber() {
-		return distsys.ErrCriticalSectionAborted
-	}
 	if !state.hasOldValue {
 		state.oldValue = res.state.value
 		state.hasOldValue = true

--- a/distsys/resources/gcounter.go
+++ b/distsys/resources/gcounter.go
@@ -34,8 +34,6 @@ type GCounter struct {
 	inCriticalSection bool
 
 	peerAddrs *immutable.Map
-
-	peersMu sync.RWMutex
 	peers   *immutable.Map
 
 	closeChan chan struct{}
@@ -182,9 +180,7 @@ func (res *GCounter) Close() error {
 	res.closeChan <- struct{}{}
 
 	res.state.stateMu.RLock()
-	res.peersMu.Lock()
 	defer res.state.stateMu.RUnlock()
-	defer res.peersMu.Unlock()
 
 	var err error
 	it := res.peers.Iterator()
@@ -218,9 +214,6 @@ func (res *GCounter) merge(other counters) {
 // tryConnectPeers tries to connect to peer nodes with timeout. If dialing
 // succeeds, retains the client for later RPC.
 func (res *GCounter) tryConnectPeers() {
-	res.peersMu.Lock()
-	defer res.peersMu.Unlock()
-
 	it := res.peerAddrs.Iterator()
 	for !it.Done() {
 		id, addr := it.Next()


### PR DESCRIPTION
* Don't abort when given non-numerical values in WriteValue, no point in abort and retrying
* If the resource is currently in critical section from `ReadValue()` or `WriteValue()`, its local value cannot change, queue up the updates to be merged after exiting critical section. Currently queue gets cleared at `Abort()` and `Commit()`.