### PR TITLE
Two for one deal on with statement gogen bugs

### DIFF
--- a/src/pgo/trans/MPCalGoCodegenPass.scala
+++ b/src/pgo/trans/MPCalGoCodegenPass.scala
@@ -363,30 +363,38 @@ object MPCalGoCodegenPass {
               d"\n// skip"
             case PCalWhile(_, _) => !!!
             case PCalWith(variables, body) =>
-              readExprs(variables.map {
-                case PCalVariableDeclarationValue(name, value) => (value, s"${name.id}Read")
-                case PCalVariableDeclarationSet(name, set) => (set, s"${name.id}Read")
-              }) { exprReads =>
-                val oldCtx = ctx
-                val cleanedNames = variables.map(decl => ctx.nameCleaner.cleanName(decl.name.id))
-                ((variables.view zip exprReads) zip cleanedNames).map {
-                  case ((PCalVariableDeclarationValue(_, _), read), name) =>
-                    d"\nvar $name $TLAValue = $read"
-                  case ((decl@PCalVariableDeclarationSet(_, _), read), name) =>
-                    // weird semantics:
-                    // - with of an empty set is just not explored, so if the set's empty we abort the critical section
-                    // - like with an either, try to keep making progress by exploring multiple possible element selections.
-                    //   this uses the same fairness mechanism as either, which approximates round-robin selection of set elements.
-                    d"\nif $read.AsSet().Len() == 0 {${
-                      d"\nreturn distsys.ErrCriticalSectionAborted".indented
-                    }\n}" +
-                      d"\nvar $name $TLAValue = $read.SelectElement(${ctx.iface}.NextFairnessCounter(\"${fairnessCounterIds(ById(decl))}\", uint($read.AsSet().Len())))"
-                }.toList.flattenDescriptions + {
-                  implicit val ctx: GoCodegenContext = oldCtx.copy(
-                    bindings = oldCtx.bindings ++ (variables.view.map(ById(_)) zip cleanedNames.view.map(FixedValueBinding)))
-                  impl(body)
+              @tailrec
+              def performBindings(variables: List[PCalVariableDeclarationBound], bindings: Description)(implicit ctx: GoCodegenContext): Description =
+                variables match {
+                  case Nil =>
+                    bindings + impl(body)
+                  case decl :: restDecls =>
+                    val cleanedName = ctx.nameCleaner.cleanName(decl.name.id)
+                    val oneBind = decl match {
+                      case PCalVariableDeclarationValue(name, value) =>
+                        readExpr(value, s"${name.id}Read") { read =>
+                          d"\nvar $cleanedName $TLAValue = $read"
+                        }
+                      case decl@PCalVariableDeclarationSet(name, set) =>
+                        readExpr(set, s"${name.id}Read") { read =>
+                          // need a temp local var to store translated read's result, or we might evaluate it up to 3 times
+                          val tempName = ctx.nameCleaner.cleanName(s"${name.id}Read")
+                          // weird semantics:
+                          // - with of an empty set is just not explored, so if the set's empty we abort the critical section
+                          // - like with an either, try to keep making progress by exploring multiple possible element selections.
+                          //   this uses the same fairness mechanism as either, which approximates round-robin selection of set elements.
+                          d"\nvar $tempName = $read" +
+                            d"\nif $tempName.AsSet().Len() == 0 {${
+                              d"\nreturn distsys.ErrCriticalSectionAborted".indented
+                            }\n}" +
+                            d"\nvar $cleanedName $TLAValue = $tempName.SelectElement(${ctx.iface}.NextFairnessCounter(\"${fairnessCounterIds(ById(decl))}\", uint($tempName.AsSet().Len())))"
+                        }
+                    }
+                    performBindings(restDecls, bindings + oneBind + d"\n_ = $cleanedName")(
+                      ctx.copy(bindings = ctx.bindings.updated(ById(decl), FixedValueBinding(cleanedName))))
                 }
-              }
+
+              performBindings(variables, d"")
           }
           impl(restStmts, pfxDesc = pfxDesc + result)
       }

--- a/test/files/general/ExprTests.tla
+++ b/test/files/general/ExprTests.tla
@@ -30,8 +30,16 @@ Test7(bar) == CASE bar = 1 -> 1
 
 Test8 == CASE FALSE -> 42
 
-\* A trivial do-nothing process
 (* --mpcal ExprTests {
+
+    archetype ANothing() {
+        lbl: \* test for gogen bug: x should be in-scope for the definition of y
+        with(x = 42, y = x) {
+            skip;
+        };
+    }
+
+    \* A trivial do-nothing process
     process (Nothing = 0) {
         \* test for a TLA+ output bug: the brackets around the nested CASE are strictly necessary; omitting them will
         \*   cause the inner CASE to steal the outer CASE's OTHER branch.

--- a/test/files/general/ExprTests.tla.expectpcal
+++ b/test/files/general/ExprTests.tla.expectpcal
@@ -30,8 +30,16 @@ Test7(bar) == CASE bar = 1 -> 1
 
 Test8 == CASE FALSE -> 42
 
-\* A trivial do-nothing process
 (* --mpcal ExprTests {
+
+    archetype ANothing() {
+        lbl: \* test for gogen bug: x should be in-scope for the definition of y
+        with(x = 42, y = x) {
+            skip;
+        };
+    }
+
+    \* A trivial do-nothing process
     process (Nothing = 0) {
         \* test for a TLA+ output bug: the brackets around the nested CASE are strictly necessary; omitting them will
         \*   cause the inner CASE to steal the outer CASE's OTHER branch.

--- a/test/files/general/ExprTests.tla.gotests/ExprTests.go
+++ b/test/files/general/ExprTests.tla.gotests/ExprTests.go
@@ -2306,4 +2306,36 @@ func Test8(iface distsys.ArchetypeInterface) tla.TLAValue {
 
 var procTable = distsys.MakeMPCalProcTable()
 
-var jumpTable = distsys.MakeMPCalJumpTable()
+var jumpTable = distsys.MakeMPCalJumpTable(
+	distsys.MPCalCriticalSection{
+		Name: "ANothing.lbl",
+		Body: func(iface distsys.ArchetypeInterface) error {
+			var err error
+			_ = err
+			var x1 tla.TLAValue = tla.MakeTLANumber(42)
+			_ = x1
+			var y1 tla.TLAValue = x1
+			_ = y1
+			// skip
+			return iface.Goto("ANothing.Done")
+			// no statements
+		},
+	},
+	distsys.MPCalCriticalSection{
+		Name: "ANothing.Done",
+		Body: func(distsys.ArchetypeInterface) error {
+			return distsys.ErrDone
+		},
+	},
+)
+
+var ANothing = distsys.MPCalArchetype{
+	Name:              "ANothing",
+	Label:             "ANothing.lbl",
+	RequiredRefParams: []string{},
+	RequiredValParams: []string{},
+	JumpTable:         jumpTable,
+	ProcTable:         procTable,
+	PreAmble: func(iface distsys.ArchetypeInterface) {
+	},
+}

--- a/test/files/general/NestedCRDTImpl.tla.gotests/NestedCRDTImpl.go
+++ b/test/files/general/NestedCRDTImpl.tla.gotests/NestedCRDTImpl.go
@@ -369,6 +369,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					return err
 				}
 				var updateVal tla.TLAValue = updateValRead
+				_ = updateVal
 				var exprRead11 tla.TLAValue
 				exprRead11, err = iface.Read(state, []tla.TLAValue{})
 				if err != nil {
@@ -386,10 +387,12 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if targetRead.AsSet().Len() == 0 {
+				var targetRead0 = targetRead
+				if targetRead0.AsSet().Len() == 0 {
 					return distsys.ErrCriticalSectionAborted
 				}
-				var target tla.TLAValue = targetRead.SelectElement(iface.NextFairnessCounter("ACRDTResource.receiveReq.1", uint(targetRead.AsSet().Len())))
+				var target tla.TLAValue = targetRead0.SelectElement(iface.NextFairnessCounter("ACRDTResource.receiveReq.1", uint(targetRead0.AsSet().Len())))
+				_ = target
 				var exprRead12 tla.TLAValue
 				exprRead12, err = iface.Read(state, []tla.TLAValue{})
 				if err != nil {

--- a/test/files/general/proxy.tla.gotests/proxy.go
+++ b/test/files/general/proxy.tla.gotests/proxy.go
@@ -238,6 +238,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					return err
 				}
 				var tmp tla.TLAValue = tmpRead
+				_ = tmp
 				var condition4 tla.TLAValue
 				condition4, err = iface.Read(idx5, []tla.TLAValue{})
 				if err != nil {

--- a/test/files/general/replicated_kv.tla.gotests/replicated_kv.go
+++ b/test/files/general/replicated_kv.tla.gotests/replicated_kv.go
@@ -390,10 +390,12 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if clientRead.AsSet().Len() == 0 {
+				var clientRead0 = clientRead
+				if clientRead0.AsSet().Len() == 0 {
 					return distsys.ErrCriticalSectionAborted
 				}
-				var client tla.TLAValue = clientRead.SelectElement(iface.NextFairnessCounter("AReplica.findMinClock.0", uint(clientRead.AsSet().Len())))
+				var client tla.TLAValue = clientRead0.SelectElement(iface.NextFairnessCounter("AReplica.findMinClock.0", uint(clientRead0.AsSet().Len())))
+				_ = client
 				var condition8 tla.TLAValue
 				condition8, err = iface.Read(minClock0, []tla.TLAValue{})
 				if err != nil {
@@ -478,15 +480,17 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				return err
 			}
 			if tla.TLA_LessThanSymbol(condition11, tla.TLA_Cardinality(condition12)).AsBool() {
-				var clientRead0 tla.TLAValue
-				clientRead0, err = iface.Read(pendingClients0, []tla.TLAValue{})
+				var clientRead1 tla.TLAValue
+				clientRead1, err = iface.Read(pendingClients0, []tla.TLAValue{})
 				if err != nil {
 					return err
 				}
-				if clientRead0.AsSet().Len() == 0 {
+				var clientRead2 = clientRead1
+				if clientRead2.AsSet().Len() == 0 {
 					return distsys.ErrCriticalSectionAborted
 				}
-				var client0 tla.TLAValue = clientRead0.SelectElement(iface.NextFairnessCounter("AReplica.findMinClient.0", uint(clientRead0.AsSet().Len())))
+				var client0 tla.TLAValue = clientRead2.SelectElement(iface.NextFairnessCounter("AReplica.findMinClient.0", uint(clientRead2.AsSet().Len())))
+				_ = client0
 				var exprRead17 tla.TLAValue
 				exprRead17, err = iface.Read(pendingRequests4, []tla.TLAValue{})
 				if err != nil {
@@ -991,10 +995,12 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if ReplicaSet(iface).AsSet().Len() == 0 {
+				var dstRead = ReplicaSet(iface)
+				if dstRead.AsSet().Len() == 0 {
 					return distsys.ErrCriticalSectionAborted
 				}
-				var dst tla.TLAValue = ReplicaSet(iface).SelectElement(iface.NextFairnessCounter("Get.getRequest.0", uint(ReplicaSet(iface).AsSet().Len())))
+				var dst tla.TLAValue = dstRead.SelectElement(iface.NextFairnessCounter("Get.getRequest.0", uint(dstRead.AsSet().Len())))
+				_ = dst
 				var exprRead49 tla.TLAValue
 				exprRead49, err = iface.Read(getReq, []tla.TLAValue{})
 				if err != nil {

--- a/test/files/gogen/bug_167.tla.gotests/bug_167.go
+++ b/test/files/gogen/bug_167.tla.gotests/bug_167.go
@@ -1403,14 +1403,18 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if tla.TLA_NotEqualsSymbol(condition55, NULL(iface)).AsBool() {
 				switch iface.NextFairnessCounter("APutClient.sndPutReq.0", 2) {
 				case 0:
-					if KEY_SET(iface).AsSet().Len() == 0 {
+					var keyRead = KEY_SET(iface)
+					if keyRead.AsSet().Len() == 0 {
 						return distsys.ErrCriticalSectionAborted
 					}
-					var key tla.TLAValue = KEY_SET(iface).SelectElement(iface.NextFairnessCounter("APutClient.sndPutReq.1", uint(KEY_SET(iface).AsSet().Len())))
-					if VALUE_SET(iface).AsSet().Len() == 0 {
+					var key tla.TLAValue = keyRead.SelectElement(iface.NextFairnessCounter("APutClient.sndPutReq.1", uint(keyRead.AsSet().Len())))
+					_ = key
+					var valueRead = VALUE_SET(iface)
+					if valueRead.AsSet().Len() == 0 {
 						return distsys.ErrCriticalSectionAborted
 					}
-					var value tla.TLAValue = VALUE_SET(iface).SelectElement(iface.NextFairnessCounter("APutClient.sndPutReq.2", uint(VALUE_SET(iface).AsSet().Len())))
+					var value tla.TLAValue = valueRead.SelectElement(iface.NextFairnessCounter("APutClient.sndPutReq.2", uint(valueRead.AsSet().Len())))
+					_ = value
 					err = iface.Write(body, []tla.TLAValue{}, tla.MakeTLARecord([]tla.TLARecordField{
 						{tla.MakeTLAString("key"), key},
 						{tla.MakeTLAString("value"), value},


### PR DESCRIPTION
Fixes #197, which helped me find two different bugs in the same ~20 LOC.

First, the reported bug: a scoping oversight meant that, unlike the rest of PGo, the handling of with statements during gogen did not consider the following to be valid:

```
with(x = 42, y = x) {
    skip;
}
```

The result was a crash, because `x` should actually be in scope of `y`'s definition, and the rest of the gogen code assumed this.

The second bug is also caused by this same example: the usual mitigation for the Go compiler considering unused local variables an error was absent from code generation for `with` statements, meaning that the code generated from the example above would not compile (complaining `y` was unused).
To fix, you just add `_ = x` and `_ = y` to keep the Go compiler happy.