### PR TITLE
Improve with statement handling in generated PCal

### DIFF
--- a/src/pgo/model/pcal/AST.scala
+++ b/src/pgo/model/pcal/AST.scala
@@ -107,4 +107,6 @@ final case class PCalSkip() extends PCalStatement
 
 final case class PCalWhile(condition: TLAExpression, body: List[PCalStatement]) extends PCalStatement
 
-final case class PCalWith(variables: List[PCalVariableDeclarationBound], body: List[PCalStatement]) extends PCalStatement
+final case class PCalWith(variables: List[PCalVariableDeclarationBound], body: List[PCalStatement]) extends PCalStatement {
+  require(variables.nonEmpty, "with statements must declare at least one name")
+}

--- a/src/pgo/trans/PCalRenderPass.scala
+++ b/src/pgo/trans/PCalRenderPass.scala
@@ -309,7 +309,7 @@ object PCalRenderPass {
       case PCalGoto(target) =>
         d"goto $target"
       case PCalIf(condition, yes, no) =>
-        d"if(${describeExpr(condition)}) {\n${
+        d"if (${describeExpr(condition)}) {\n${
           describeStatements(yes).indented
         }\n}${
           if(no.nonEmpty) {
@@ -331,13 +331,24 @@ object PCalRenderPass {
       case PCalReturn() => d"return"
       case PCalSkip() => d"skip"
       case PCalWhile(condition, body) =>
-        d"while(${describeExpr(condition)}) {\n${
+        d"while (${describeExpr(condition)}) {\n${
           describeStatements(body).indented
         }\n}"
       case PCalWith(variables, body) =>
-        d"with (${variables.view.map(describeVarDecl).separateBy(d", ")}) {\n${
+        val bodyDesc = d"{\n${
           describeStatements(body).indented
         }\n}"
+        if(variables.size > 1) {
+          d"with (${
+            variables.view.map { decl =>
+              d"\n${describeVarDecl(decl)}"
+            }
+              .separateBy(d", ")
+              .indented
+          }\n) $bodyDesc"
+        } else {
+          d"with (${variables.view.map(describeVarDecl).separateBy(d", ")}) $bodyDesc"
+        }
     }
 
   def describeStatements(stmts: List[PCalStatement], tailSemicolon: Boolean = true): Description =

--- a/test/files/general/NestedCRDTImpl.tla.expectpcal
+++ b/test/files/general/NestedCRDTImpl.tla.expectpcal
@@ -309,8 +309,8 @@ preCommitAck:
           in := [in EXCEPT ![self] = EMPTY_CELL];
           with (yielded_in0 = v00) {
             req := yielded_in0;
-            if(((req).tpe) = (READ_REQ)) {
-              if(~ (criticalSectionInProgress)) {
+            if (((req).tpe) = (READ_REQ)) {
+              if (~ (criticalSectionInProgress)) {
                 readState := state;
                 criticalSectionInProgress := TRUE;
                 with (value00 = [tpe |-> READ_ACK, value |-> VIEW_FN(readState)]) {
@@ -326,8 +326,8 @@ preCommitAck:
                 };
               };
             } else {
-              if(((req).tpe) = (WRITE_REQ)) {
-                if(~ (criticalSectionInProgress)) {
+              if (((req).tpe) = (WRITE_REQ)) {
+                if (~ (criticalSectionInProgress)) {
                   with (readState1 = state) {
                     criticalSectionInProgress := TRUE;
                     readState := UPDATE_FN(self, readState1, (req).value);
@@ -346,7 +346,7 @@ preCommitAck:
                   };
                 };
               } else {
-                if(((req).tpe) = (ABORT_REQ)) {
+                if (((req).tpe) = (ABORT_REQ)) {
                   readState := ZERO_VALUE;
                   criticalSectionInProgress := FALSE;
                   with (value20 = [tpe |-> ABORT_ACK]) {
@@ -355,15 +355,15 @@ preCommitAck:
                     goto receiveReq;
                   };
                 } else {
-                  if(((req).tpe) = (PRECOMMIT_REQ)) {
+                  if (((req).tpe) = (PRECOMMIT_REQ)) {
                     with (value30 = [tpe |-> PRECOMMIT_ACK]) {
                       await ((out)[self]) = (EMPTY_CELL);
                       out := [out EXCEPT ![self] = value30];
                       goto receiveReq;
                     };
                   } else {
-                    if(((req).tpe) = (COMMIT_REQ)) {
-                      if((state) # (readState)) {
+                    if (((req).tpe) = (COMMIT_REQ)) {
+                      if ((state) # (readState)) {
                         remainingPeersToUpdate := peers;
                         state := COMBINE_FN(state, readState);
                         readState := ZERO_VALUE;
@@ -397,21 +397,23 @@ preCommitAck:
         await (Len((network)[self])) > (0);
         with (msg00 = Head((network)[self])) {
           network := [network EXCEPT ![self] = Tail((network)[self])];
-          with (yielded_network0 = msg00) {
-            with (updateVal1 = yielded_network0) {
-              state := COMBINE_FN(updateVal1, state);
-              goto receiveReq;
-            };
+          with (
+            yielded_network0 = msg00, 
+            updateVal1 = yielded_network0
+          ) {
+            state := COMBINE_FN(updateVal1, state);
+            goto receiveReq;
           };
         };
       } or {
-        with (target1 \in remainingPeersToUpdate) {
-          with (value50 = state) {
-            await (Len((network)[target1])) < (BUFFER_SIZE);
-            network := [network EXCEPT ![target1] = Append((network)[target1], value50)];
-            remainingPeersToUpdate := (remainingPeersToUpdate) \ ({target1});
-            goto receiveReq;
-          };
+        with (
+          target1 \in remainingPeersToUpdate, 
+          value50 = state
+        ) {
+          await (Len((network)[target1])) < (BUFFER_SIZE);
+          network := [network EXCEPT ![target1] = Append((network)[target1], value50)];
+          remainingPeersToUpdate := (remainingPeersToUpdate) \ ({target1});
+          goto receiveReq;
         };
       };
   }

--- a/test/files/general/PBFail4_bug125.tla.expectpcal
+++ b/test/files/general/PBFail4_bug125.tla.expectpcal
@@ -253,7 +253,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
     variables msg; respBody; respTyp; idx; repMsg; rep; resp;
   {
     replicaLoop:
-      if(TRUE) {
+      if (TRUE) {
         goto rcvMsg;
       } else {
         goto failLabel;
@@ -266,10 +266,10 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
           with (yielded_network4 = msg00) {
             msg := yielded_network4;
             assert ((msg).to) = (self);
-            if(((msg).srcTyp) = (CLIENT_SRC)) {
+            if (((msg).srcTyp) = (CLIENT_SRC)) {
               goto handlePrimary;
             } else {
-              if(((msg).srcTyp) = (PRIMARY_SRC)) {
+              if (((msg).srcTyp) = (PRIMARY_SRC)) {
                 goto handleBackup;
               } else {
                 goto handleBackup;
@@ -284,10 +284,10 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
           with (yielded_network00 = msg10) {
             msg := yielded_network00;
             assert ((msg).to) = (self);
-            if(((msg).srcTyp) = (CLIENT_SRC)) {
+            if (((msg).srcTyp) = (CLIENT_SRC)) {
               goto handlePrimary;
             } else {
-              if(((msg).srcTyp) = (PRIMARY_SRC)) {
+              if (((msg).srcTyp) = (PRIMARY_SRC)) {
                 goto handleBackup;
               } else {
                 goto handleBackup;
@@ -297,7 +297,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
         };
       };
     handleBackup:
-      if(((msg).typ) = (GET_REQ)) {
+      if (((msg).typ) = (GET_REQ)) {
         with (yielded_fs1 = (fs)[<<self, ((msg).body).key>>]) {
           respBody := yielded_fs1;
           respTyp := GET_RESP;
@@ -309,7 +309,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
           };
         };
       } else {
-        if(((msg).typ) = (PUT_REQ)) {
+        if (((msg).typ) = (PUT_REQ)) {
           with (value00 = ((msg).body).value) {
             fs := [fs EXCEPT ![<<self, ((msg).body).key>>] = value00];
             respBody := ACK_MSG;
@@ -331,14 +331,14 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
         };
       };
     handlePrimary:
-      if(((msg).typ) = (GET_REQ)) {
+      if (((msg).typ) = (GET_REQ)) {
         with (yielded_fs00 = (fs)[<<self, ((msg).body).key>>]) {
           respBody := yielded_fs00;
           respTyp := GET_RESP;
           goto sndResp;
         };
       } else {
-        if(((msg).typ) = (PUT_REQ)) {
+        if (((msg).typ) = (PUT_REQ)) {
           with (value20 = ((msg).body).value) {
             fs := [fs EXCEPT ![<<self, ((msg).body).key>>] = value20];
             respBody := ACK_MSG;
@@ -353,14 +353,14 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
       idx := 1;
       goto sndMsgLoop;
     sndMsgLoop:
-      if((idx) <= (NUM_REPLICAS)) {
+      if ((idx) <= (NUM_REPLICAS)) {
         goto sndMsg;
       } else {
         goto rcvReplicaMsg;
       };
     sndMsg:
       with (yielded_fd5 = (fd)[idx]) {
-        if(((yielded_fd5) = (TRUE)) /\ ((idx) # (self))) {
+        if (((yielded_fd5) = (TRUE)) /\ ((idx) # (self))) {
           repMsg := [from |-> self, to |-> idx, body |-> (msg).body, srcTyp |-> PRIMARY_SRC, typ |-> PUT_REQ, id |-> (msg).id];
           with (value30 = repMsg) {
             await (Len((network)[<<idx, PUT_REQ>>])) < (BUFFER_SIZE);
@@ -377,14 +377,14 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
       idx := 1;
       goto rcvMsgLoop;
     rcvMsgLoop:
-      if((idx) <= (NUM_REPLICAS)) {
+      if ((idx) <= (NUM_REPLICAS)) {
         goto rcvMsgFromReplica;
       } else {
         goto sndResp;
       };
     rcvMsgFromReplica:
       with (yielded_fd00 = (fd)[idx]) {
-        if(((yielded_fd00) = (TRUE)) /\ ((idx) # (self))) {
+        if (((yielded_fd00) = (TRUE)) /\ ((idx) # (self))) {
           await (Len((network)[<<self, PUT_RESP>>])) > (0);
           with (msg20 = Head((network)[<<self, PUT_RESP>>])) {
             network := [network EXCEPT ![<<self, PUT_RESP>>] = Tail((network)[<<self, PUT_RESP>>])];
@@ -426,14 +426,14 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
       idx0 := 1;
       goto sndPutReqLoop;
     sndPutReqLoop:
-      if((idx0) <= (NUM_REPLICAS)) {
+      if ((idx0) <= (NUM_REPLICAS)) {
         goto sndPutMsg;
       } else {
         goto rcvPutResp;
       };
     sndPutMsg:
       with (yielded_fd1 = (fd)[idx0]) {
-        if((yielded_fd1) = (TRUE)) {
+        if ((yielded_fd1) = (TRUE)) {
           body := [key |-> KEY1, value |-> VALUE1];
           req := [from |-> self, to |-> idx0, body |-> body, srcTyp |-> CLIENT_SRC, typ |-> PUT_REQ, id |-> 1];
           with (value60 = req) {
@@ -447,7 +447,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
       };
     rcvPutResp:
       with (yielded_fd2 = (fd)[idx0]) {
-        if((yielded_fd2) = (TRUE)) {
+        if ((yielded_fd2) = (TRUE)) {
           await (Len((network)[<<self, PUT_RESP>>])) > (0);
           with (msg30 = Head((network)[<<self, PUT_RESP>>])) {
             network := [network EXCEPT ![<<self, PUT_RESP>>] = Tail((network)[<<self, PUT_RESP>>])];
@@ -470,14 +470,14 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
       idx0 := 1;
       goto sndGetReqLoop;
     sndGetReqLoop:
-      if((idx0) <= (NUM_REPLICAS)) {
+      if ((idx0) <= (NUM_REPLICAS)) {
         goto sndGetMsg;
       } else {
         goto rcvGetResp;
       };
     sndGetMsg:
       with (yielded_fd3 = (fd)[idx0]) {
-        if((yielded_fd3) = (TRUE)) {
+        if ((yielded_fd3) = (TRUE)) {
           body := [key |-> KEY1, value |-> TEMP_VAL];
           req := [from |-> self, to |-> idx0, body |-> body, srcTyp |-> CLIENT_SRC, typ |-> GET_REQ, id |-> 2];
           with (value70 = req) {
@@ -491,7 +491,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_CLIENTS > 0
       };
     rcvGetResp:
       with (yielded_fd4 = (fd)[idx0]) {
-        if((yielded_fd4) = (TRUE)) {
+        if ((yielded_fd4) = (TRUE)) {
           await (Len((network)[<<self, GET_RESP>>])) > (0);
           with (msg40 = Head((network)[<<self, GET_RESP>>])) {
             network := [network EXCEPT ![<<self, GET_RESP>>] = Tail((network)[<<self, GET_RESP>>])];

--- a/test/files/general/ProcedureSpaghetti.tla.expectpcal
+++ b/test/files/general/ProcedureSpaghetti.tla.expectpcal
@@ -76,11 +76,12 @@ process (Pross5 = 5) {
   procedure Proc20()
   {
     Proc2lbl1:
-      with (yielded_V11 = (V1) + (1)) {
-        with (value1 = (yielded_V11) + (1)) {
-          V1 := (value1) - (1);
-          return;
-        };
+      with (
+        yielded_V11 = (V1) + (1), 
+        value1 = (yielded_V11) + (1)
+      ) {
+        V1 := (value1) - (1);
+        return;
       };
   }
   
@@ -91,11 +92,12 @@ process (Pross5 = 5) {
       call Proc20();
       goto Proc1lbl2;
     Proc1lbl2:
-      with (yielded_V100 = (V1) + (1)) {
-        with (value00 = (yielded_V100) + (b)) {
-          V1 := (value00) - (1);
-          return;
-        };
+      with (
+        yielded_V100 = (V1) + (1), 
+        value00 = (yielded_V100) + (b)
+      ) {
+        V1 := (value00) - (1);
+        return;
       };
   }
   

--- a/test/files/general/bug2_124.tla.expectpcal
+++ b/test/files/general/bug2_124.tla.expectpcal
@@ -48,7 +48,7 @@ CONSTANTS NUM_NODES, BUFFER_SIZE
     variables msg;
   {
     serverLoop:
-      if(TRUE) {
+      if (TRUE) {
         goto rcvMsg;
       } else {
         goto Done;

--- a/test/files/general/dqueue.tla.expectpcal
+++ b/test/files/general/dqueue.tla.expectpcal
@@ -85,7 +85,7 @@ CONSTANTS BUFFER_SIZE, NUM_CONSUMERS, PRODUCER
   fair process (Consumer \in (1) .. (NUM_CONSUMERS))
   {
     c:
-      if(TRUE) {
+      if (TRUE) {
         goto c1;
       } else {
         goto Done;
@@ -111,7 +111,7 @@ CONSTANTS BUFFER_SIZE, NUM_CONSUMERS, PRODUCER
     variables requester;
   {
     p:
-      if(TRUE) {
+      if (TRUE) {
         goto p1;
       } else {
         goto Done;
@@ -127,12 +127,13 @@ CONSTANTS BUFFER_SIZE, NUM_CONSUMERS, PRODUCER
       };
     p2:
       stream := ((stream) + (1)) % (BUFFER_SIZE);
-      with (yielded_stream0 = stream) {
-        with (value00 = yielded_stream0) {
-          await (Len((network)[requester])) < (BUFFER_SIZE);
-          network := [network EXCEPT ![requester] = Append((network)[requester], value00)];
-          goto p;
-        };
+      with (
+        yielded_stream0 = stream, 
+        value00 = yielded_stream0
+      ) {
+        await (Len((network)[requester])) < (BUFFER_SIZE);
+        network := [network EXCEPT ![requester] = Append((network)[requester], value00)];
+        goto p;
       };
   }
 }

--- a/test/files/general/load_balancer.tla.expectpcal
+++ b/test/files/general/load_balancer.tla.expectpcal
@@ -251,7 +251,7 @@ CONSTANT WEB_PAGE
     variables msg; next = 0;
   {
     main:
-      if(TRUE) {
+      if (TRUE) {
         goto rcvMsg;
       } else {
         goto Done;
@@ -279,7 +279,7 @@ CONSTANT WEB_PAGE
     variables msg0;
   {
     serverLoop:
-      if(TRUE) {
+      if (TRUE) {
         goto rcvReq;
       } else {
         goto Done;
@@ -294,12 +294,13 @@ CONSTANT WEB_PAGE
         };
       };
     sendPage:
-      with (yielded_fs0 = WEB_PAGE) {
-        with (value00 = yielded_fs0) {
-          await (Len((network)[(msg0).client_id])) < (BUFFER_SIZE);
-          network := [network EXCEPT ![(msg0).client_id] = Append((network)[(msg0).client_id], value00)];
-          goto serverLoop;
-        };
+      with (
+        yielded_fs0 = WEB_PAGE, 
+        value00 = yielded_fs0
+      ) {
+        await (Len((network)[(msg0).client_id])) < (BUFFER_SIZE);
+        network := [network EXCEPT ![(msg0).client_id] = Append((network)[(msg0).client_id], value00)];
+        goto serverLoop;
       };
   }
   
@@ -307,7 +308,7 @@ CONSTANT WEB_PAGE
     variables req; resp;
   {
     clientLoop:
-      if(TRUE) {
+      if (TRUE) {
         goto clientRequest;
       } else {
         goto Done;

--- a/test/files/general/pbkvs.tla.expectpcal
+++ b/test/files/general/pbkvs.tla.expectpcal
@@ -488,21 +488,21 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
     variables req; respBody; respTyp; idx; repReq; repResp; resp; replicaSet; shouldSync = FALSE; lastPutBody = [versionNumber |-> 0]; replica;
   {
     replicaLoop:
-      if(TRUE) {
+      if (TRUE) {
         replicaSet := (REPLICA_SET) \ ({self});
         idx := 1;
-        if(EXPLORE_FAIL) {
+        if (EXPLORE_FAIL) {
           either {
             skip;
             goto syncPrimary;
           } or {
-            with (value00 = FALSE) {
-              with (network0 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value00]]) {
-                with (value110 = FALSE) {
-                  network := [network0 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network0)[<<self, RESP_INDEX>>]).queue, enabled |-> value110]];
-                  goto failLabel;
-                };
-              };
+            with (
+              value00 = FALSE, 
+              network0 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value00]], 
+              value110 = FALSE
+            ) {
+              network := [network0 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network0)[<<self, RESP_INDEX>>]).queue, enabled |-> value110]];
+              goto failLabel;
             };
           };
         } else {
@@ -512,9 +512,9 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
         goto failLabel;
       };
     syncPrimary:
-      if((Cardinality(primary)) > (0)) {
+      if ((Cardinality(primary)) > (0)) {
         with (yielded_primary = CHOOSE x \in primary : \A r \in primary : (x) <= (r)) {
-          if(((yielded_primary) = (self)) /\ (shouldSync)) {
+          if (((yielded_primary) = (self)) /\ (shouldSync)) {
             shouldSync := TRUE;
             goto sndSyncReqLoop;
           } else {
@@ -523,7 +523,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
         };
       } else {
         with (yielded_primary0 = NULL) {
-          if(((yielded_primary0) = (self)) /\ (shouldSync)) {
+          if (((yielded_primary0) = (self)) /\ (shouldSync)) {
             shouldSync := TRUE;
             goto sndSyncReqLoop;
           } else {
@@ -532,27 +532,27 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
         };
       };
     sndSyncReqLoop:
-      if((idx) <= (NUM_REPLICAS)) {
-        if((idx) # (self)) {
+      if ((idx) <= (NUM_REPLICAS)) {
+        if ((idx) # (self)) {
           either {
             repReq := [from |-> self, to |-> idx, body |-> lastPutBody, srcTyp |-> PRIMARY_SRC, typ |-> SYNC_REQ, id |-> 3];
             with (value20 = repReq) {
               await ((network)[<<idx, REQ_INDEX>>]).enabled;
               with (network1 = [network EXCEPT ![<<idx, REQ_INDEX>>] = [queue |-> Append(((network)[<<idx, REQ_INDEX>>]).queue, value20), enabled |-> ((network)[<<idx, REQ_INDEX>>]).enabled]]) {
                 idx := (idx) + (1);
-                if(EXPLORE_FAIL) {
+                if (EXPLORE_FAIL) {
                   either {
                     skip;
                     network := network1;
                     goto sndSyncReqLoop;
                   } or {
-                    with (value30 = FALSE) {
-                      with (network2 = [network1 EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network1)[<<self, REQ_INDEX>>]).queue, enabled |-> value30]]) {
-                        with (value40 = FALSE) {
-                          network := [network2 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network2)[<<self, RESP_INDEX>>]).queue, enabled |-> value40]];
-                          goto failLabel;
-                        };
-                      };
+                    with (
+                      value30 = FALSE, 
+                      network2 = [network1 EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network1)[<<self, REQ_INDEX>>]).queue, enabled |-> value30]], 
+                      value40 = FALSE
+                    ) {
+                      network := [network2 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network2)[<<self, RESP_INDEX>>]).queue, enabled |-> value40]];
+                      goto failLabel;
                     };
                   };
                 } else {
@@ -565,18 +565,18 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
             with (yielded_fd10 = (fd)[idx]) {
               await yielded_fd10;
               idx := (idx) + (1);
-              if(EXPLORE_FAIL) {
+              if (EXPLORE_FAIL) {
                 either {
                   skip;
                   goto sndSyncReqLoop;
                 } or {
-                  with (value31 = FALSE) {
-                    with (network3 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value31]]) {
-                      with (value41 = FALSE) {
-                        network := [network3 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network3)[<<self, RESP_INDEX>>]).queue, enabled |-> value41]];
-                        goto failLabel;
-                      };
-                    };
+                  with (
+                    value31 = FALSE, 
+                    network3 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value31]], 
+                    value41 = FALSE
+                  ) {
+                    network := [network3 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network3)[<<self, RESP_INDEX>>]).queue, enabled |-> value41]];
+                    goto failLabel;
                   };
                 };
               } else {
@@ -586,18 +586,18 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
           };
         } else {
           idx := (idx) + (1);
-          if(EXPLORE_FAIL) {
+          if (EXPLORE_FAIL) {
             either {
               skip;
               goto sndSyncReqLoop;
             } or {
-              with (value32 = FALSE) {
-                with (network4 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value32]]) {
-                  with (value42 = FALSE) {
-                    network := [network4 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network4)[<<self, RESP_INDEX>>]).queue, enabled |-> value42]];
-                    goto failLabel;
-                  };
-                };
+              with (
+                value32 = FALSE, 
+                network4 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value32]], 
+                value42 = FALSE
+              ) {
+                network := [network4 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network4)[<<self, RESP_INDEX>>]).queue, enabled |-> value42]];
+                goto failLabel;
               };
             };
           } else {
@@ -608,7 +608,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
         goto rcvSyncRespLoop;
       };
     rcvSyncRespLoop:
-      if((Cardinality(replicaSet)) > (0)) {
+      if ((Cardinality(replicaSet)) > (0)) {
         either {
           assert ((network)[<<self, RESP_INDEX>>]).enabled;
           await (Len(((network)[<<self, RESP_INDEX>>]).queue)) > (0);
@@ -618,7 +618,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
               repResp := yielded_network8;
               with (yielded_fd00 = (fd)[(repResp).from]) {
                 assert ((((((repResp).id) = (3)) /\ (((repResp).to) = (self))) /\ (((repResp).srcTyp) = (BACKUP_SRC))) /\ (((repResp).typ) = (SYNC_RESP))) /\ ((((repResp).from) \in (replicaSet)) \/ (yielded_fd00));
-                if((((repResp).body).versionNumber) > ((lastPutBody).versionNumber)) {
+                if ((((repResp).body).versionNumber) > ((lastPutBody).versionNumber)) {
                   with (value50 = ((repResp).body).value) {
                     fs := [fs EXCEPT ![self][((repResp).body).key] = value50];
                     lastPutBody := (repResp).body;
@@ -635,21 +635,22 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
           };
         } or {
           replica := CHOOSE r \in replicaSet : TRUE;
-          with (yielded_fd11 = (fd)[replica]) {
-            with (yielded_network00 = Len(((network)[<<self, RESP_INDEX>>]).queue)) {
-              await (yielded_fd11) /\ ((yielded_network00) = (0));
-              replicaSet := (replicaSet) \ ({replica});
-              goto rcvSyncRespLoop;
-            };
+          with (
+            yielded_fd11 = (fd)[replica], 
+            yielded_network00 = Len(((network)[<<self, RESP_INDEX>>]).queue)
+          ) {
+            await (yielded_fd11) /\ ((yielded_network00) = (0));
+            replicaSet := (replicaSet) \ ({replica});
+            goto rcvSyncRespLoop;
           };
         };
       } else {
         goto rcvMsg;
       };
     rcvMsg:
-      if((Cardinality(primary)) > (0)) {
+      if ((Cardinality(primary)) > (0)) {
         with (yielded_primary3 = CHOOSE x \in primary : \A r \in primary : (x) <= (r)) {
-          if(((yielded_primary3) = (self)) /\ (shouldSync)) {
+          if (((yielded_primary3) = (self)) /\ (shouldSync)) {
             goto syncPrimary;
           } else {
             assert ((network)[<<self, REQ_INDEX>>]).enabled;
@@ -659,9 +660,9 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
               with (yielded_network10 = readMsg10) {
                 req := yielded_network10;
                 assert ((req).to) = (self);
-                if((Cardinality(primary)) > (0)) {
+                if ((Cardinality(primary)) > (0)) {
                   with (yielded_primary1 = CHOOSE x \in primary : \A r \in primary : (x) <= (r)) {
-                    if(((yielded_primary1) = (self)) /\ (((req).srcTyp) = (CLIENT_SRC))) {
+                    if (((yielded_primary1) = (self)) /\ (((req).srcTyp) = (CLIENT_SRC))) {
                       goto handlePrimary;
                     } else {
                       goto handleBackup;
@@ -669,7 +670,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
                   };
                 } else {
                   with (yielded_primary2 = NULL) {
-                    if(((yielded_primary2) = (self)) /\ (((req).srcTyp) = (CLIENT_SRC))) {
+                    if (((yielded_primary2) = (self)) /\ (((req).srcTyp) = (CLIENT_SRC))) {
                       goto handlePrimary;
                     } else {
                       goto handleBackup;
@@ -682,7 +683,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
         };
       } else {
         with (yielded_primary4 = NULL) {
-          if(((yielded_primary4) = (self)) /\ (shouldSync)) {
+          if (((yielded_primary4) = (self)) /\ (shouldSync)) {
             goto syncPrimary;
           } else {
             assert ((network)[<<self, REQ_INDEX>>]).enabled;
@@ -692,9 +693,9 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
               with (yielded_network11 = readMsg11) {
                 req := yielded_network11;
                 assert ((req).to) = (self);
-                if((Cardinality(primary)) > (0)) {
+                if ((Cardinality(primary)) > (0)) {
                   with (yielded_primary1 = CHOOSE x \in primary : \A r \in primary : (x) <= (r)) {
-                    if(((yielded_primary1) = (self)) /\ (((req).srcTyp) = (CLIENT_SRC))) {
+                    if (((yielded_primary1) = (self)) /\ (((req).srcTyp) = (CLIENT_SRC))) {
                       goto handlePrimary;
                     } else {
                       goto handleBackup;
@@ -702,7 +703,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
                   };
                 } else {
                   with (yielded_primary2 = NULL) {
-                    if(((yielded_primary2) = (self)) /\ (((req).srcTyp) = (CLIENT_SRC))) {
+                    if (((yielded_primary2) = (self)) /\ (((req).srcTyp) = (CLIENT_SRC))) {
                       goto handlePrimary;
                     } else {
                       goto handleBackup;
@@ -716,7 +717,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
       };
     handleBackup:
       assert ((req).srcTyp) = (PRIMARY_SRC);
-      if(((req).typ) = (GET_REQ)) {
+      if (((req).typ) = (GET_REQ)) {
         with (yielded_fs1 = ((fs)[self])[((req).body).key]) {
           respBody := [content |-> yielded_fs1];
           respTyp := GET_RESP;
@@ -735,7 +736,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
           };
         };
       } else {
-        if(((req).typ) = (PUT_REQ)) {
+        if (((req).typ) = (PUT_REQ)) {
           with (value60 = ((req).body).value) {
             fs := [fs EXCEPT ![self][((req).body).key] = value60];
             assert (((req).body).versionNumber) > ((lastPutBody).versionNumber);
@@ -758,8 +759,8 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
             };
           };
         } else {
-          if(((req).typ) = (SYNC_REQ)) {
-            if((((req).body).versionNumber) > ((lastPutBody).versionNumber)) {
+          if (((req).typ) = (SYNC_REQ)) {
+            if ((((req).body).versionNumber) > ((lastPutBody).versionNumber)) {
               with (value70 = ((req).body).value) {
                 fs := [fs EXCEPT ![self][((req).body).key] = value70];
                 lastPutBody := (req).body;
@@ -817,14 +818,14 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
       };
     handlePrimary:
       assert ((req).srcTyp) = (CLIENT_SRC);
-      if(((req).typ) = (GET_REQ)) {
+      if (((req).typ) = (GET_REQ)) {
         with (yielded_fs00 = ((fs)[self])[((req).body).key]) {
           respBody := [content |-> yielded_fs00];
           respTyp := GET_RESP;
           goto sndResp;
         };
       } else {
-        if(((req).typ) = (PUT_REQ)) {
+        if (((req).typ) = (PUT_REQ)) {
           with (value90 = ((req).body).value) {
             fs := [fs EXCEPT ![self][((req).body).key] = value90];
             lastPutBody := [versionNumber |-> ((lastPutBody).versionNumber) + (1), key |-> ((req).body).key, value |-> ((req).body).value];
@@ -839,27 +840,27 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
         };
       };
     sndReplicaReqLoop:
-      if((idx) <= (NUM_REPLICAS)) {
-        if((idx) # (self)) {
+      if ((idx) <= (NUM_REPLICAS)) {
+        if ((idx) # (self)) {
           either {
             repReq := [from |-> self, to |-> idx, body |-> lastPutBody, srcTyp |-> PRIMARY_SRC, typ |-> PUT_REQ, id |-> (req).id];
             with (value100 = repReq) {
               await ((network)[<<idx, REQ_INDEX>>]).enabled;
               with (network5 = [network EXCEPT ![<<idx, REQ_INDEX>>] = [queue |-> Append(((network)[<<idx, REQ_INDEX>>]).queue, value100), enabled |-> ((network)[<<idx, REQ_INDEX>>]).enabled]]) {
                 idx := (idx) + (1);
-                if(EXPLORE_FAIL) {
+                if (EXPLORE_FAIL) {
                   either {
                     skip;
                     network := network5;
                     goto sndReplicaReqLoop;
                   } or {
-                    with (value111 = FALSE) {
-                      with (network6 = [network5 EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network5)[<<self, REQ_INDEX>>]).queue, enabled |-> value111]]) {
-                        with (value120 = FALSE) {
-                          network := [network6 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network6)[<<self, RESP_INDEX>>]).queue, enabled |-> value120]];
-                          goto failLabel;
-                        };
-                      };
+                    with (
+                      value111 = FALSE, 
+                      network6 = [network5 EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network5)[<<self, REQ_INDEX>>]).queue, enabled |-> value111]], 
+                      value120 = FALSE
+                    ) {
+                      network := [network6 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network6)[<<self, RESP_INDEX>>]).queue, enabled |-> value120]];
+                      goto failLabel;
                     };
                   };
                 } else {
@@ -872,18 +873,18 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
             with (yielded_fd30 = (fd)[idx]) {
               await yielded_fd30;
               idx := (idx) + (1);
-              if(EXPLORE_FAIL) {
+              if (EXPLORE_FAIL) {
                 either {
                   skip;
                   goto sndReplicaReqLoop;
                 } or {
-                  with (value112 = FALSE) {
-                    with (network7 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value112]]) {
-                      with (value121 = FALSE) {
-                        network := [network7 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network7)[<<self, RESP_INDEX>>]).queue, enabled |-> value121]];
-                        goto failLabel;
-                      };
-                    };
+                  with (
+                    value112 = FALSE, 
+                    network7 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value112]], 
+                    value121 = FALSE
+                  ) {
+                    network := [network7 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network7)[<<self, RESP_INDEX>>]).queue, enabled |-> value121]];
+                    goto failLabel;
                   };
                 };
               } else {
@@ -893,18 +894,18 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
           };
         } else {
           idx := (idx) + (1);
-          if(EXPLORE_FAIL) {
+          if (EXPLORE_FAIL) {
             either {
               skip;
               goto sndReplicaReqLoop;
             } or {
-              with (value113 = FALSE) {
-                with (network8 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value113]]) {
-                  with (value122 = FALSE) {
-                    network := [network8 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network8)[<<self, RESP_INDEX>>]).queue, enabled |-> value122]];
-                    goto failLabel;
-                  };
-                };
+              with (
+                value113 = FALSE, 
+                network8 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value113]], 
+                value122 = FALSE
+              ) {
+                network := [network8 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network8)[<<self, RESP_INDEX>>]).queue, enabled |-> value122]];
+                goto failLabel;
               };
             };
           } else {
@@ -915,63 +916,64 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
         goto rcvReplicaRespLoop;
       };
     rcvReplicaRespLoop:
-      if((Cardinality(replicaSet)) > (0)) {
+      if ((Cardinality(replicaSet)) > (0)) {
         either {
           assert ((network)[<<self, RESP_INDEX>>]).enabled;
           await (Len(((network)[<<self, RESP_INDEX>>]).queue)) > (0);
-          with (readMsg20 = Head(((network)[<<self, RESP_INDEX>>]).queue)) {
-            with (network9 = [network EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> Tail(((network)[<<self, RESP_INDEX>>]).queue), enabled |-> ((network)[<<self, RESP_INDEX>>]).enabled]]) {
-              with (yielded_network20 = readMsg20) {
-                repResp := yielded_network20;
-                with (yielded_fd40 = (fd)[(repResp).from]) {
-                  assert ((((((((repResp).from) \in (replicaSet)) \/ (yielded_fd40)) /\ (((repResp).to) = (self))) /\ (((repResp).body) = (ACK_MSG_BODY))) /\ (((repResp).srcTyp) = (BACKUP_SRC))) /\ (((repResp).typ) = (PUT_RESP))) /\ (((repResp).id) = ((req).id));
-                  replicaSet := (replicaSet) \ ({(repResp).from});
-                  if(EXPLORE_FAIL) {
-                    either {
-                      skip;
-                      network := network9;
-                      goto rcvReplicaRespLoop;
-                    } or {
-                      with (value130 = FALSE) {
-                        with (network10 = [network9 EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network9)[<<self, REQ_INDEX>>]).queue, enabled |-> value130]]) {
-                          with (value140 = FALSE) {
-                            network := [network10 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network10)[<<self, RESP_INDEX>>]).queue, enabled |-> value140]];
-                            goto failLabel;
-                          };
-                        };
-                      };
-                    };
-                  } else {
-                    network := network9;
-                    goto rcvReplicaRespLoop;
+          with (
+            readMsg20 = Head(((network)[<<self, RESP_INDEX>>]).queue), 
+            network9 = [network EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> Tail(((network)[<<self, RESP_INDEX>>]).queue), enabled |-> ((network)[<<self, RESP_INDEX>>]).enabled]], 
+            yielded_network20 = readMsg20
+          ) {
+            repResp := yielded_network20;
+            with (yielded_fd40 = (fd)[(repResp).from]) {
+              assert ((((((((repResp).from) \in (replicaSet)) \/ (yielded_fd40)) /\ (((repResp).to) = (self))) /\ (((repResp).body) = (ACK_MSG_BODY))) /\ (((repResp).srcTyp) = (BACKUP_SRC))) /\ (((repResp).typ) = (PUT_RESP))) /\ (((repResp).id) = ((req).id));
+              replicaSet := (replicaSet) \ ({(repResp).from});
+              if (EXPLORE_FAIL) {
+                either {
+                  skip;
+                  network := network9;
+                  goto rcvReplicaRespLoop;
+                } or {
+                  with (
+                    value130 = FALSE, 
+                    network10 = [network9 EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network9)[<<self, REQ_INDEX>>]).queue, enabled |-> value130]], 
+                    value140 = FALSE
+                  ) {
+                    network := [network10 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network10)[<<self, RESP_INDEX>>]).queue, enabled |-> value140]];
+                    goto failLabel;
                   };
                 };
+              } else {
+                network := network9;
+                goto rcvReplicaRespLoop;
               };
             };
           };
         } or {
           replica := CHOOSE r \in replicaSet : TRUE;
-          with (yielded_fd50 = (fd)[replica]) {
-            with (yielded_network30 = Len(((network)[<<self, RESP_INDEX>>]).queue)) {
-              await (yielded_fd50) /\ ((yielded_network30) = (0));
-              replicaSet := (replicaSet) \ ({replica});
-              if(EXPLORE_FAIL) {
-                either {
-                  skip;
-                  goto rcvReplicaRespLoop;
-                } or {
-                  with (value131 = FALSE) {
-                    with (network11 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value131]]) {
-                      with (value141 = FALSE) {
-                        network := [network11 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network11)[<<self, RESP_INDEX>>]).queue, enabled |-> value141]];
-                        goto failLabel;
-                      };
-                    };
-                  };
-                };
-              } else {
+          with (
+            yielded_fd50 = (fd)[replica], 
+            yielded_network30 = Len(((network)[<<self, RESP_INDEX>>]).queue)
+          ) {
+            await (yielded_fd50) /\ ((yielded_network30) = (0));
+            replicaSet := (replicaSet) \ ({replica});
+            if (EXPLORE_FAIL) {
+              either {
+                skip;
                 goto rcvReplicaRespLoop;
+              } or {
+                with (
+                  value131 = FALSE, 
+                  network11 = [network EXCEPT ![<<self, REQ_INDEX>>] = [queue |-> ((network)[<<self, REQ_INDEX>>]).queue, enabled |-> value131]], 
+                  value141 = FALSE
+                ) {
+                  network := [network11 EXCEPT ![<<self, RESP_INDEX>>] = [queue |-> ((network11)[<<self, RESP_INDEX>>]).queue, enabled |-> value141]];
+                  goto failLabel;
+                };
               };
+            } else {
+              goto rcvReplicaRespLoop;
             };
           };
         };
@@ -999,17 +1001,17 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
     variables req0; resp0; body; replica0; output = putOutput;
   {
     putClientLoop:
-      if(PUT_CLIENT_RUN) {
+      if (PUT_CLIENT_RUN) {
         body := putInput;
         goto sndPutReq;
       } else {
         goto Done;
       };
     sndPutReq:
-      if((Cardinality(primary)) > (0)) {
+      if ((Cardinality(primary)) > (0)) {
         with (yielded_primary50 = CHOOSE x \in primary : \A r \in primary : (x) <= (r)) {
           replica0 := yielded_primary50;
-          if((replica0) # (NULL)) {
+          if ((replica0) # (NULL)) {
             either {
               req0 := [from |-> self, to |-> replica0, body |-> body, srcTyp |-> CLIENT_SRC, typ |-> PUT_REQ, id |-> 1];
               with (value180 = req0) {
@@ -1030,7 +1032,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
       } else {
         with (yielded_primary60 = NULL) {
           replica0 := yielded_primary60;
-          if((replica0) # (NULL)) {
+          if ((replica0) # (NULL)) {
             either {
               req0 := [from |-> self, to |-> replica0, body |-> body, srcTyp |-> CLIENT_SRC, typ |-> PUT_REQ, id |-> 1];
               with (value181 = req0) {
@@ -1063,11 +1065,12 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
           };
         };
       } or {
-        with (yielded_fd70 = (fd)[replica0]) {
-          with (yielded_network50 = Len(((network)[<<self, RESP_INDEX>>]).queue)) {
-            await (yielded_fd70) /\ ((yielded_network50) = (0));
-            goto sndPutReq;
-          };
+        with (
+          yielded_fd70 = (fd)[replica0], 
+          yielded_network50 = Len(((network)[<<self, RESP_INDEX>>]).queue)
+        ) {
+          await (yielded_fd70) /\ ((yielded_network50) = (0));
+          goto sndPutReq;
         };
       };
   }
@@ -1076,17 +1079,17 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
     variables req1; resp1; body0; replica1;
   {
     getClientLoop:
-      if(GET_CLIENT_RUN) {
+      if (GET_CLIENT_RUN) {
         body0 := getInput;
         goto sndGetReq;
       } else {
         goto Done;
       };
     sndGetReq:
-      if((Cardinality(primary)) > (0)) {
+      if ((Cardinality(primary)) > (0)) {
         with (yielded_primary70 = CHOOSE x \in primary : \A r \in primary : (x) <= (r)) {
           replica1 := yielded_primary70;
-          if((replica1) # (NULL)) {
+          if ((replica1) # (NULL)) {
             either {
               req1 := [from |-> self, to |-> replica1, body |-> body0, srcTyp |-> CLIENT_SRC, typ |-> GET_REQ, id |-> 2];
               with (value190 = req1) {
@@ -1107,7 +1110,7 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
       } else {
         with (yielded_primary80 = NULL) {
           replica1 := yielded_primary80;
-          if((replica1) # (NULL)) {
+          if ((replica1) # (NULL)) {
             either {
               req1 := [from |-> self, to |-> replica1, body |-> body0, srcTyp |-> CLIENT_SRC, typ |-> GET_REQ, id |-> 2];
               with (value191 = req1) {
@@ -1140,11 +1143,12 @@ ASSUME NUM_REPLICAS > 0 /\ NUM_PUT_CLIENTS >= 0 /\ NUM_GET_CLIENTS >= 0
           };
         };
       } or {
-        with (yielded_fd90 = (fd)[replica1]) {
-          with (yielded_network70 = Len(((network)[<<self, RESP_INDEX>>]).queue)) {
-            await (yielded_fd90) /\ ((yielded_network70) = (0));
-            goto sndGetReq;
-          };
+        with (
+          yielded_fd90 = (fd)[replica1], 
+          yielded_network70 = Len(((network)[<<self, RESP_INDEX>>]).queue)
+        ) {
+          await (yielded_fd90) /\ ((yielded_network70) = (0));
+          goto sndGetReq;
         };
       };
   }

--- a/test/files/general/proxy.tla.expectpcal
+++ b/test/files/general/proxy.tla.expectpcal
@@ -231,7 +231,7 @@ ASSUME NUM_SERVERS > 0 /\ NUM_CLIENTS > 0
     variables msg; proxyMsg; idx; resp; proxyResp;
   {
     proxyLoop:
-      if(TRUE) {
+      if (TRUE) {
         assert ((network)[<<ProxyID, REQ_MSG_TYP>>]).enabled;
         await (Len(((network)[<<ProxyID, REQ_MSG_TYP>>]).queue)) > (0);
         with (readMsg00 = Head(((network)[<<ProxyID, REQ_MSG_TYP>>]).queue)) {
@@ -248,7 +248,7 @@ ASSUME NUM_SERVERS > 0 /\ NUM_CLIENTS > 0
         goto Done;
       };
     serversLoop:
-      if((idx) <= (NUM_SERVERS)) {
+      if ((idx) <= (NUM_SERVERS)) {
         either {
           proxyMsg := [from |-> ProxyID, to |-> idx, body |-> (msg).body, id |-> (msg).id, typ |-> PROXY_REQ_MSG_TYP];
           with (value7 = proxyMsg) {
@@ -272,15 +272,16 @@ ASSUME NUM_SERVERS > 0 /\ NUM_CLIENTS > 0
         await (Len(((network)[<<ProxyID, PROXY_RESP_MSG_TYP>>]).queue)) > (0);
         with (readMsg1 = Head(((network)[<<ProxyID, PROXY_RESP_MSG_TYP>>]).queue)) {
           network := [network EXCEPT ![<<ProxyID, PROXY_RESP_MSG_TYP>>] = [queue |-> Tail(((network)[<<ProxyID, PROXY_RESP_MSG_TYP>>]).queue), enabled |-> ((network)[<<ProxyID, PROXY_RESP_MSG_TYP>>]).enabled]];
-          with (yielded_network0 = readMsg1) {
-            with (tmp = yielded_network0) {
-              if((((tmp).from) # (idx)) \/ (((tmp).id) # ((msg).id))) {
-                goto proxyRcvMsg;
-              } else {
-                proxyResp := tmp;
-                assert (((((proxyResp).to) = (ProxyID)) /\ (((proxyResp).from) = (idx))) /\ (((proxyResp).id) = ((msg).id))) /\ (((proxyResp).typ) = (PROXY_RESP_MSG_TYP));
-                goto sendMsgToClient;
-              };
+          with (
+            yielded_network0 = readMsg1, 
+            tmp = yielded_network0
+          ) {
+            if ((((tmp).from) # (idx)) \/ (((tmp).id) # ((msg).id))) {
+              goto proxyRcvMsg;
+            } else {
+              proxyResp := tmp;
+              assert (((((proxyResp).to) = (ProxyID)) /\ (((proxyResp).from) = (idx))) /\ (((proxyResp).id) = ((msg).id))) /\ (((proxyResp).typ) = (PROXY_RESP_MSG_TYP));
+              goto sendMsgToClient;
             };
           };
         };
@@ -304,8 +305,8 @@ ASSUME NUM_SERVERS > 0 /\ NUM_CLIENTS > 0
     variables msg0; resp0;
   {
     serverLoop:
-      if(TRUE) {
-        if(EXPLORE_FAIL) {
+      if (TRUE) {
+        if (EXPLORE_FAIL) {
           either {
             skip;
             goto serverRcvMsg;
@@ -324,27 +325,27 @@ ASSUME NUM_SERVERS > 0 /\ NUM_CLIENTS > 0
     serverRcvMsg:
       assert ((network)[<<self, PROXY_REQ_MSG_TYP>>]).enabled;
       await (Len(((network)[<<self, PROXY_REQ_MSG_TYP>>]).queue)) > (0);
-      with (readMsg20 = Head(((network)[<<self, PROXY_REQ_MSG_TYP>>]).queue)) {
-        with (network0 = [network EXCEPT ![<<self, PROXY_REQ_MSG_TYP>>] = [queue |-> Tail(((network)[<<self, PROXY_REQ_MSG_TYP>>]).queue), enabled |-> ((network)[<<self, PROXY_REQ_MSG_TYP>>]).enabled]]) {
-          with (yielded_network10 = readMsg20) {
-            msg0 := yielded_network10;
-            assert ((((msg0).to) = (self)) /\ (((msg0).from) = (ProxyID))) /\ (((msg0).typ) = (PROXY_REQ_MSG_TYP));
-            if(EXPLORE_FAIL) {
-              either {
-                skip;
-                network := network0;
-                goto serverSendMsg;
-              } or {
-                with (value20 = FALSE) {
-                  network := [network0 EXCEPT ![self, PROXY_REQ_MSG_TYP] = [queue |-> ((network0)[self, PROXY_REQ_MSG_TYP]).queue, enabled |-> value20]];
-                  goto failLabel;
-                };
-              };
-            } else {
-              network := network0;
-              goto serverSendMsg;
+      with (
+        readMsg20 = Head(((network)[<<self, PROXY_REQ_MSG_TYP>>]).queue), 
+        network0 = [network EXCEPT ![<<self, PROXY_REQ_MSG_TYP>>] = [queue |-> Tail(((network)[<<self, PROXY_REQ_MSG_TYP>>]).queue), enabled |-> ((network)[<<self, PROXY_REQ_MSG_TYP>>]).enabled]], 
+        yielded_network10 = readMsg20
+      ) {
+        msg0 := yielded_network10;
+        assert ((((msg0).to) = (self)) /\ (((msg0).from) = (ProxyID))) /\ (((msg0).typ) = (PROXY_REQ_MSG_TYP));
+        if (EXPLORE_FAIL) {
+          either {
+            skip;
+            network := network0;
+            goto serverSendMsg;
+          } or {
+            with (value20 = FALSE) {
+              network := [network0 EXCEPT ![self, PROXY_REQ_MSG_TYP] = [queue |-> ((network0)[self, PROXY_REQ_MSG_TYP]).queue, enabled |-> value20]];
+              goto failLabel;
             };
           };
+        } else {
+          network := network0;
+          goto serverSendMsg;
         };
       };
     serverSendMsg:
@@ -352,7 +353,7 @@ ASSUME NUM_SERVERS > 0 /\ NUM_CLIENTS > 0
       with (value30 = resp0) {
         await ((network)[<<(resp0).to, (resp0).typ>>]).enabled;
         with (network1 = [network EXCEPT ![<<(resp0).to, (resp0).typ>>] = [queue |-> Append(((network)[<<(resp0).to, (resp0).typ>>]).queue, value30), enabled |-> ((network)[<<(resp0).to, (resp0).typ>>]).enabled]]) {
-          if(EXPLORE_FAIL) {
+          if (EXPLORE_FAIL) {
             either {
               skip;
               network := network1;
@@ -380,7 +381,7 @@ ASSUME NUM_SERVERS > 0 /\ NUM_CLIENTS > 0
     variables req; resp1; reqId = 0; input = self;
   {
     clientLoop:
-      if(CLIENT_RUN) {
+      if (CLIENT_RUN) {
         req := [from |-> self, to |-> ProxyID, body |-> input, id |-> reqId, typ |-> REQ_MSG_TYP];
         with (value60 = req) {
           await ((network)[<<(req).to, (req).typ>>]).enabled;

--- a/test/files/general/replicated_kv.tla.expectpcal
+++ b/test/files/general/replicated_kv.tla.expectpcal
@@ -656,7 +656,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
     variables liveClients = ClientSet; pendingRequests = [c \in liveClients |-> <<>>]; stableMessages = <<>>; i; firstPending; timestamp; nextClient; lowestPending; chooseMessage; currentClocks = [c \in liveClients |-> 0]; minClock; continue; pendingClients; clientsIter; msg; ok; key; val; kv = [k \in KeySpace |-> NULL];
   {
     replicaLoop:
-      if(TRUE) {
+      if (TRUE) {
         stableMessages := <<>>;
         continue := TRUE;
         goto receiveClientRequest;
@@ -673,14 +673,14 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         };
       };
     clientDisconnected:
-      if(((msg).op) = (DISCONNECT_MSG)) {
+      if (((msg).op) = (DISCONNECT_MSG)) {
         liveClients := (liveClients) \ ({(msg).client});
         goto replicaGetRequest;
       } else {
         goto replicaGetRequest;
       };
     replicaGetRequest:
-      if(((msg).op) = (GET_MSG)) {
+      if (((msg).op) = (GET_MSG)) {
         assert ((msg).client) \in (liveClients);
         currentClocks := [currentClocks EXCEPT ![(msg).client] = (msg).timestamp];
         pendingRequests := [pendingRequests EXCEPT ![(msg).client] = Append((pendingRequests)[(msg).client], msg)];
@@ -689,7 +689,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         goto replicaPutRequest;
       };
     replicaPutRequest:
-      if(((msg).op) = (PUT_MSG)) {
+      if (((msg).op) = (PUT_MSG)) {
         currentClocks := [currentClocks EXCEPT ![(msg).client] = (msg).timestamp];
         pendingRequests := [pendingRequests EXCEPT ![(msg).client] = Append((pendingRequests)[(msg).client], msg)];
         goto replicaNullRequest;
@@ -697,14 +697,14 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         goto replicaNullRequest;
       };
     replicaNullRequest:
-      if(((msg).op) = (NULL_MSG)) {
+      if (((msg).op) = (NULL_MSG)) {
         currentClocks := [currentClocks EXCEPT ![(msg).client] = (msg).timestamp];
         goto findStableRequestsLoop;
       } else {
         goto findStableRequestsLoop;
       };
     findStableRequestsLoop:
-      if(continue) {
+      if (continue) {
         pendingClients := {c \in liveClients : (Len((pendingRequests)[c])) > (0)};
         nextClient := (NUM_NODES) + (1);
         clientsIter := liveClients;
@@ -716,9 +716,9 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         goto respondPendingRequestsLoop;
       };
     findMinClock:
-      if((i) < (Cardinality(clientsIter))) {
+      if ((i) < (Cardinality(clientsIter))) {
         with (client \in clientsIter) {
-          if(((minClock) = (0)) \/ (((currentClocks)[client]) < (minClock))) {
+          if (((minClock) = (0)) \/ (((currentClocks)[client]) < (minClock))) {
             minClock := (currentClocks)[client];
             clientsIter := (clientsIter) \ ({client});
             goto findMinClock;
@@ -733,14 +733,14 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         goto findMinClient;
       };
     findMinClient:
-      if((i) < (Cardinality(pendingClients))) {
+      if ((i) < (Cardinality(pendingClients))) {
         with (client \in pendingClients) {
           firstPending := Head((pendingRequests)[client]);
           assert (((firstPending).op) = (GET_MSG)) \/ (((firstPending).op) = (PUT_MSG));
           timestamp := (firstPending).timestamp;
-          if((timestamp) < (minClock)) {
+          if ((timestamp) < (minClock)) {
             chooseMessage := ((timestamp) < (lowestPending)) \/ (((timestamp) = (lowestPending)) /\ ((client) < (nextClient)));
-            if(chooseMessage) {
+            if (chooseMessage) {
               nextClient := client;
               lowestPending := timestamp;
               pendingClients := (pendingClients) \ ({client});
@@ -758,7 +758,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         goto addStableMessage;
       };
     addStableMessage:
-      if((lowestPending) < (minClock)) {
+      if ((lowestPending) < (minClock)) {
         msg := Head((pendingRequests)[nextClient]);
         pendingRequests := [pendingRequests EXCEPT ![nextClient] = Tail((pendingRequests)[nextClient])];
         stableMessages := Append(stableMessages, msg);
@@ -768,7 +768,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         goto findStableRequestsLoop;
       };
     respondPendingRequestsLoop:
-      if((i) <= (Len(stableMessages))) {
+      if ((i) <= (Len(stableMessages))) {
         msg := (stableMessages)[i];
         i := (i) + (1);
         goto respondStableGet;
@@ -776,7 +776,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         goto replicaLoop;
       };
     respondStableGet:
-      if(((msg).op) = (GET_MSG)) {
+      if (((msg).op) = (GET_MSG)) {
         key := (msg).key;
         with (yielded_kv0 = (kv)[key]) {
           val := yielded_kv0;
@@ -790,7 +790,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         goto respondStablePut;
       };
     respondStablePut:
-      if(((msg).op) = (PUT_MSG)) {
+      if (((msg).op) = (PUT_MSG)) {
         key := (msg).key;
         val := (msg).value;
         with (value10 = val) {
@@ -810,31 +810,34 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
     variables continue0 = TRUE; getReq; getResp; key0 = GET_KEY; spin = TRUE;
   {
     getLoop:
-      if(continue0) {
+      if (continue0) {
         goto getRequest;
       } else {
         goto Done;
       };
     getRequest:
       with (yielded_cid3 = (self) - ((NUM_CLIENTS) * (GET_ORDER))) {
-        if(((clocks)[yielded_cid3]) = (- (1))) {
+        if (((clocks)[yielded_cid3]) = (- (1))) {
           continue0 := FALSE;
           goto getCheckSpin;
         } else {
-          with (yielded_cid00 = (self) - ((NUM_CLIENTS) * (GET_ORDER))) {
-            with (yielded_cid20 = (self) - ((NUM_CLIENTS) * (GET_ORDER))) {
-              clocks := [clocks EXCEPT ![yielded_cid00] = ((clocks)[yielded_cid20]) + (1)];
-              with (yielded_cid21 = (self) - ((NUM_CLIENTS) * (GET_ORDER))) {
-                with (yielded_cid110 = (self) - ((NUM_CLIENTS) * (GET_ORDER))) {
-                  getReq := [op |-> GET_MSG, key |-> key0, client |-> yielded_cid21, timestamp |-> (clocks)[yielded_cid110], reply_to |-> self];
-                  with (dst \in ReplicaSet) {
-                    with (value30 = getReq) {
-                      await (Len((replicasNetwork)[dst])) < (BUFFER_SIZE);
-                      replicasNetwork := [replicasNetwork EXCEPT ![dst] = Append((replicasNetwork)[dst], value30)];
-                      goto getReply;
-                    };
-                  };
-                };
+          with (
+            yielded_cid00 = (self) - ((NUM_CLIENTS) * (GET_ORDER)), 
+            yielded_cid20 = (self) - ((NUM_CLIENTS) * (GET_ORDER))
+          ) {
+            clocks := [clocks EXCEPT ![yielded_cid00] = ((clocks)[yielded_cid20]) + (1)];
+            with (
+              yielded_cid21 = (self) - ((NUM_CLIENTS) * (GET_ORDER)), 
+              yielded_cid110 = (self) - ((NUM_CLIENTS) * (GET_ORDER))
+            ) {
+              getReq := [op |-> GET_MSG, key |-> key0, client |-> yielded_cid21, timestamp |-> (clocks)[yielded_cid110], reply_to |-> self];
+              with (
+                dst \in ReplicaSet, 
+                value30 = getReq
+              ) {
+                await (Len((replicasNetwork)[dst])) < (BUFFER_SIZE);
+                replicasNetwork := [replicasNetwork EXCEPT ![dst] = Append((replicasNetwork)[dst], value30)];
+                goto getReply;
               };
             };
           };
@@ -842,7 +845,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
       };
     getReply:
       with (yielded_cid4 = (self) - ((NUM_CLIENTS) * (GET_ORDER))) {
-        if(((clocks)[yielded_cid4]) = (- (1))) {
+        if (((clocks)[yielded_cid4]) = (- (1))) {
           continue0 := FALSE;
           goto getCheckSpin;
         } else {
@@ -859,7 +862,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         };
       };
     getCheckSpin:
-      if(~ (spin)) {
+      if (~ (spin)) {
         continue0 := FALSE;
         goto getLoop;
       } else {
@@ -871,35 +874,37 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
     variables continue1 = TRUE; i0; j; putReq; putResp; key1 = PUT_KEY; value = PUT_VALUE; spin0 = TRUE;
   {
     putLoop:
-      if(continue1) {
+      if (continue1) {
         goto putRequest;
       } else {
         goto Done;
       };
     putRequest:
       with (yielded_cid9 = (self) - ((NUM_CLIENTS) * (PUT_ORDER))) {
-        if(((clocks)[yielded_cid9]) = (- (1))) {
+        if (((clocks)[yielded_cid9]) = (- (1))) {
           continue1 := FALSE;
           goto putCheckSpin;
         } else {
-          with (yielded_cid60 = (self) - ((NUM_CLIENTS) * (PUT_ORDER))) {
-            with (yielded_cid50 = (self) - ((NUM_CLIENTS) * (PUT_ORDER))) {
-              clocks := [clocks EXCEPT ![yielded_cid60] = ((clocks)[yielded_cid50]) + (1)];
-              with (yielded_cid80 = (self) - ((NUM_CLIENTS) * (PUT_ORDER))) {
-                with (yielded_cid70 = (self) - ((NUM_CLIENTS) * (PUT_ORDER))) {
-                  putReq := [op |-> PUT_MSG, key |-> key1, value |-> value, client |-> yielded_cid80, timestamp |-> (clocks)[yielded_cid70], reply_to |-> self];
-                  i0 := 0;
-                  j := 0;
-                  goto putBroadcast;
-                };
-              };
+          with (
+            yielded_cid60 = (self) - ((NUM_CLIENTS) * (PUT_ORDER)), 
+            yielded_cid50 = (self) - ((NUM_CLIENTS) * (PUT_ORDER))
+          ) {
+            clocks := [clocks EXCEPT ![yielded_cid60] = ((clocks)[yielded_cid50]) + (1)];
+            with (
+              yielded_cid80 = (self) - ((NUM_CLIENTS) * (PUT_ORDER)), 
+              yielded_cid70 = (self) - ((NUM_CLIENTS) * (PUT_ORDER))
+            ) {
+              putReq := [op |-> PUT_MSG, key |-> key1, value |-> value, client |-> yielded_cid80, timestamp |-> (clocks)[yielded_cid70], reply_to |-> self];
+              i0 := 0;
+              j := 0;
+              goto putBroadcast;
             };
           };
         };
       };
     putBroadcast:
       with (yielded_cid10 = (self) - ((NUM_CLIENTS) * (PUT_ORDER))) {
-        if(((j) <= ((NUM_REPLICAS) - (1))) /\ (((clocks)[yielded_cid10]) # (- (1)))) {
+        if (((j) <= ((NUM_REPLICAS) - (1))) /\ (((clocks)[yielded_cid10]) # (- (1)))) {
           with (value40 = putReq) {
             await (Len((replicasNetwork)[j])) < (BUFFER_SIZE);
             replicasNetwork := [replicasNetwork EXCEPT ![j] = Append((replicasNetwork)[j], value40)];
@@ -911,9 +916,9 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         };
       };
     putResponse:
-      if((i0) < (Cardinality(ReplicaSet))) {
+      if ((i0) < (Cardinality(ReplicaSet))) {
         with (yielded_cid11 = (self) - ((NUM_CLIENTS) * (PUT_ORDER))) {
-          if(((clocks)[yielded_cid11]) = (- (1))) {
+          if (((clocks)[yielded_cid11]) = (- (1))) {
             continue1 := FALSE;
             goto putLoop;
           } else {
@@ -936,7 +941,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
       out := PUT_RESPONSE;
       goto putCheckSpin;
     putCheckSpin:
-      if(~ (spin0)) {
+      if (~ (spin0)) {
         continue1 := FALSE;
         goto putLoop;
       } else {
@@ -957,7 +962,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         };
       };
     disconnectBroadcast:
-      if(((j0) <= ((NUM_REPLICAS) - (1))) /\ ((0) # (- (1)))) {
+      if (((j0) <= ((NUM_REPLICAS) - (1))) /\ ((0) # (- (1)))) {
         with (value50 = msg0) {
           await (Len((replicasNetwork)[j0])) < (BUFFER_SIZE);
           replicasNetwork := [replicasNetwork EXCEPT ![j0] = Append((replicasNetwork)[j0], value50)];
@@ -973,22 +978,24 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
     variables continue2 = TRUE; j1; msg1; spin1 = TRUE;
   {
     clockUpdateLoop:
-      if(continue2) {
+      if (continue2) {
         with (yielded_cid18 = (self) - ((NUM_CLIENTS) * (NULL_ORDER))) {
-          if(((clocks)[yielded_cid18]) = (- (1))) {
+          if (((clocks)[yielded_cid18]) = (- (1))) {
             continue2 := FALSE;
             goto nullCheckSpin;
           } else {
-            with (yielded_cid150 = (self) - ((NUM_CLIENTS) * (NULL_ORDER))) {
-              with (yielded_cid140 = (self) - ((NUM_CLIENTS) * (NULL_ORDER))) {
-                clocks := [clocks EXCEPT ![yielded_cid150] = ((clocks)[yielded_cid140]) + (1)];
-                with (yielded_cid170 = (self) - ((NUM_CLIENTS) * (NULL_ORDER))) {
-                  with (yielded_cid160 = (self) - ((NUM_CLIENTS) * (NULL_ORDER))) {
-                    msg1 := [op |-> NULL_MSG, client |-> yielded_cid170, timestamp |-> (clocks)[yielded_cid160]];
-                    j1 := 0;
-                    goto nullBroadcast;
-                  };
-                };
+            with (
+              yielded_cid150 = (self) - ((NUM_CLIENTS) * (NULL_ORDER)), 
+              yielded_cid140 = (self) - ((NUM_CLIENTS) * (NULL_ORDER))
+            ) {
+              clocks := [clocks EXCEPT ![yielded_cid150] = ((clocks)[yielded_cid140]) + (1)];
+              with (
+                yielded_cid170 = (self) - ((NUM_CLIENTS) * (NULL_ORDER)), 
+                yielded_cid160 = (self) - ((NUM_CLIENTS) * (NULL_ORDER))
+              ) {
+                msg1 := [op |-> NULL_MSG, client |-> yielded_cid170, timestamp |-> (clocks)[yielded_cid160]];
+                j1 := 0;
+                goto nullBroadcast;
               };
             };
           };
@@ -998,7 +1005,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
       };
     nullBroadcast:
       with (yielded_cid19 = (self) - ((NUM_CLIENTS) * (NULL_ORDER))) {
-        if(((j1) <= ((NUM_REPLICAS) - (1))) /\ (((clocks)[yielded_cid19]) # (- (1)))) {
+        if (((j1) <= ((NUM_REPLICAS) - (1))) /\ (((clocks)[yielded_cid19]) # (- (1)))) {
           with (value60 = msg1) {
             await (Len((replicasNetwork)[j1])) < (BUFFER_SIZE);
             replicasNetwork := [replicasNetwork EXCEPT ![j1] = Append((replicasNetwork)[j1], value60)];
@@ -1010,7 +1017,7 @@ NullSet == (NUM_REPLICAS+3*NUM_CLIENTS)..(NUM_REPLICAS+4*NUM_CLIENTS-1)
         };
       };
     nullCheckSpin:
-      if(~ (spin1)) {
+      if (~ (spin1)) {
         continue2 := FALSE;
         goto clockUpdateLoop;
       } else {

--- a/test/files/pcalgen/AssignmentRulesNoMultipleWrites.tla.expectpcal
+++ b/test/files/pcalgen/AssignmentRulesNoMultipleWrites.tla.expectpcal
@@ -61,9 +61,9 @@ EXTENDS Sequences, FiniteSets, Integers
       n := 2;
       goto l2;
     l2:
-      if((n) < (10)) {
+      if ((n) < (10)) {
         with (n0 = 12) {
-          if((n0) = (20)) {
+          if ((n0) = (20)) {
             n := 100;
             goto l2;
           } else {
@@ -76,7 +76,7 @@ EXTENDS Sequences, FiniteSets, Integers
         goto l3;
       };
     l3:
-      if((n) = (32)) {
+      if ((n) = (32)) {
         with (n1 = 0) {
           n := 12;
           goto Done;

--- a/test/files/pcalgen/DontEatMyLabels.tla.expectpcal
+++ b/test/files/pcalgen/DontEatMyLabels.tla.expectpcal
@@ -257,7 +257,7 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
     variables currentTerm = 0; votedFor = Nil; log = <<>>; state = Follower; commitIndex = 0; lastApplied = 0; v; nextIndex; matchIndex; idx; votes = [t \in (0) .. (Terms) |-> {}]; msg; applied = [s \in (0) .. (Slots) |-> {}]; values = {1};
   {
     Start:
-      if(((commitIndex) < (Slots)) /\ ((currentTerm) < (Terms))) {
+      if (((commitIndex) < (Slots)) /\ ((currentTerm) < (Terms))) {
         either {
           goto N1;
         } or {
@@ -274,15 +274,15 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
         mailboxes := [mailboxes EXCEPT ![self] = Tail((mailboxes)[self])];
         with (yielded_mailboxes0 = msg00) {
           msg := yielded_mailboxes0;
-          if(((msg).type) = (AppendEntries)) {
-            if(((msg).term) < (currentTerm)) {
+          if (((msg).type) = (AppendEntries)) {
+            if (((msg).term) < (currentTerm)) {
               goto N2;
             } else {
-              if(((Len(log)) < ((msg).prevIndex)) \/ ((((log)[(msg).prevIndex]).term) # ((msg).prevTerm))) {
+              if (((Len(log)) < ((msg).prevIndex)) \/ ((((log)[(msg).prevIndex]).term) # ((msg).prevTerm))) {
                 log := SubSeq(log, 1, ((msg).prevIndex) - (1));
                 goto N3;
               } else {
-                if((Len(log)) = ((msg).prevIndex)) {
+                if ((Len(log)) = ((msg).prevIndex)) {
                   log := (log) \o ((msg).entries);
                   goto N4;
                 } else {
@@ -291,11 +291,11 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
               };
             };
           } else {
-            if(((msg).type) = (RequestVote)) {
-              if(((msg).term) < (currentTerm)) {
+            if (((msg).type) = (RequestVote)) {
+              if (((msg).term) < (currentTerm)) {
                 goto N6;
               } else {
-                if((((votedFor) = (Nil)) \/ ((votedFor) = ((msg).sender))) /\ ((((msg).prevTerm) > (Term(log, Len(log)))) \/ ((((msg).prevTerm) = (Term(log, Len(log)))) /\ (((msg).prevIndex) >= (Len(log)))))) {
+                if ((((votedFor) = (Nil)) \/ ((votedFor) = ((msg).sender))) /\ ((((msg).prevTerm) > (Term(log, Len(log)))) \/ ((((msg).prevTerm) = (Term(log, Len(log)))) /\ (((msg).prevIndex) >= (Len(log)))))) {
                   log := SubSeq(log, 1, ((msg).prevIndex) - (1));
                   goto N7;
                 } else {
@@ -303,8 +303,8 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
                 };
               };
             } else {
-              if((((msg).type) = (AppendEntriesResponse)) /\ ((state) = (Leader))) {
-                if((msg).granted) {
+              if ((((msg).type) = (AppendEntriesResponse)) /\ ((state) = (Leader))) {
+                if ((msg).granted) {
                   nextIndex := [nextIndex EXCEPT ![(msg).sender] = ((msg).prevIndex) + (1)];
                   matchIndex := [matchIndex EXCEPT ![(msg).sender] = (msg).prevIndex];
                   goto loop2;
@@ -313,10 +313,10 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
                   goto N8;
                 };
               } else {
-                if(((msg).type) = (RequestVoteResponse)) {
-                  if(((msg).granted) /\ ((state) = (Candidate))) {
+                if (((msg).type) = (RequestVoteResponse)) {
+                  if (((msg).granted) /\ ((state) = (Candidate))) {
                     votes := [votes EXCEPT ![(msg).term] = ((votes)[(msg).term]) \union ({(msg).sender})];
-                    if(((Cardinality((votes)[(msg).term])) * (2)) > (Cardinality(Servers))) {
+                    if (((Cardinality((votes)[(msg).term])) * (2)) > (Cardinality(Servers))) {
                       state := Leader;
                       matchIndex := [s3 \in Servers |-> 0];
                       nextIndex := [s4 \in Servers |-> 0];
@@ -351,17 +351,17 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
         goto N5;
       };
     N5:
-      if(((msg).term) > (currentTerm)) {
+      if (((msg).term) > (currentTerm)) {
         state := Follower;
         currentTerm := (msg).term;
-        if(((msg).leaderCommit) > (commitIndex)) {
+        if (((msg).leaderCommit) > (commitIndex)) {
           commitIndex := IF ((msg).leaderCommit) < (Len(log)) THEN (msg).leaderCommit ELSE Len((log)[self]);
           goto loop1;
         } else {
           goto Start;
         };
       } else {
-        if(((msg).leaderCommit) > (commitIndex)) {
+        if (((msg).leaderCommit) > (commitIndex)) {
           commitIndex := IF ((msg).leaderCommit) < (Len(log)) THEN (msg).leaderCommit ELSE Len((log)[self]);
           goto loop1;
         } else {
@@ -369,7 +369,7 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
         };
       };
     loop1:
-      if((lastApplied) <= (commitIndex)) {
+      if ((lastApplied) <= (commitIndex)) {
         with (value20 = (log)[lastApplied]) {
           applied := [applied EXCEPT ![lastApplied] = ((applied)[lastApplied]) \union ({value20})];
           lastApplied := (lastApplied) + (1);
@@ -389,14 +389,14 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
         goto Start;
       };
     loop2:
-      if((((Cardinality({i \in Servers : ((matchIndex)[idx]) > (commitIndex)})) * (2)) > (Cardinality(Servers))) /\ ((Term(log, (commitIndex) + (1))) = (currentTerm))) {
+      if ((((Cardinality({i \in Servers : ((matchIndex)[idx]) > (commitIndex)})) * (2)) > (Cardinality(Servers))) /\ ((Term(log, (commitIndex) + (1))) = (currentTerm))) {
         commitIndex := (commitIndex) + (1);
         goto loop2;
       } else {
         goto loop3;
       };
     loop3:
-      if((lastApplied) <= (commitIndex)) {
+      if ((lastApplied) <= (commitIndex)) {
         with (value50 = (log)[lastApplied]) {
           applied := [applied EXCEPT ![lastApplied] = ((applied)[lastApplied]) \union ({value50})];
           lastApplied := (lastApplied) + (1);
@@ -411,7 +411,7 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
         goto Start;
       };
     N9:
-      if((state) # (Leader)) {
+      if ((state) # (Leader)) {
         state := Candidate;
         currentTerm := (currentTerm) + (1);
         votes := [votes EXCEPT ![currentTerm] = {self}];
@@ -422,7 +422,7 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
         goto Start;
       };
     loop4:
-      if((idx) < (Cardinality(Servers))) {
+      if ((idx) < (Cardinality(Servers))) {
         with (value70 = [type |-> RequestVote, term |-> self, sender |-> currentTerm, entries |-> <<>>, prevIndex |-> Len(log), prevTerm |-> Term(log, Len(log)), granted |-> FALSE]) {
           mailboxes := [mailboxes EXCEPT ![idx] = Append((mailboxes)[idx], value70)];
           idx := (idx) + (1);
@@ -432,7 +432,7 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
         goto Start;
       };
     N10:
-      if((state) = (Leader)) {
+      if ((state) = (Leader)) {
         with (msg10 = Head(values)) {
           values := Tail(values);
           with (yielded_values0 = msg10) {
@@ -448,8 +448,8 @@ loop5:          SendAppendEntries(network, currentTerm, self, nextIndex, matchIn
         goto Start;
       };
     loop5:
-      if((idx) < (Cardinality(Servers))) {
-        if((idx) # (self)) {
+      if ((idx) < (Cardinality(Servers))) {
+        if ((idx) # (self)) {
           with (value80 = [type |-> RequestVote, term |-> currentTerm, sender |-> self, entries |-> SubSeq(log, (nextIndex)[idx], Len(log)), prevIndex |-> ((nextIndex)[idx]) - (1), prevTerm |-> Term(log, ((nextIndex)[idx]) - (1)), granted |-> FALSE]) {
             mailboxes := [mailboxes EXCEPT ![idx] = Append((mailboxes)[idx], value80)];
             idx := (idx) + (1);

--- a/test/files/pcalgen/MappingMacroNestedWithExpansion.tla.expectpcal
+++ b/test/files/pcalgen/MappingMacroNestedWithExpansion.tla.expectpcal
@@ -37,25 +37,19 @@ process (Proc = 1) == instance Arch(ref bar)
   process (Proc = 1)
   {
     lbl:
-      with (x00 = bar) {
-        with (yielded_bar1 = x00) {
-          with (value1 = (yielded_bar1) + (1)) {
-            with (y00 = value1) {
-              with (bar0 = y00) {
-                with (x10 = bar0) {
-                  with (yielded_bar00 = x10) {
-                    with (value00 = (2) + (yielded_bar00)) {
-                      with (y10 = value00) {
-                        bar := y10;
-                        goto Done;
-                      };
-                    };
-                  };
-                };
-              };
-            };
-          };
-        };
+      with (
+        x00 = bar, 
+        yielded_bar1 = x00, 
+        value1 = (yielded_bar1) + (1), 
+        y00 = value1, 
+        bar0 = y00, 
+        x10 = bar0, 
+        yielded_bar00 = x10, 
+        value00 = (2) + (yielded_bar00), 
+        y10 = value00
+      ) {
+        bar := y10;
+        goto Done;
       };
   }
 }

--- a/test/files/pcalgen/MultiWithSemantics.tla
+++ b/test/files/pcalgen/MultiWithSemantics.tla
@@ -1,0 +1,41 @@
+---- MODULE MultiWithSemantics ----
+EXTENDS TLC, Integers, Sequences
+
+(* --mpcal MultiWithSemantics {
+
+mapping macro Inc {
+    read {
+        with(v = $variable) {
+            $variable := $variable + 1;
+            yield v;
+        };
+    }
+    write {
+        assert FALSE;
+    }
+}
+
+archetype AnExample(ref foo) {
+lbl:
+    with(x = foo, y = foo + x) {
+        print y;
+    };
+}
+
+variables gFoo = 0;
+
+fair process (Example = 1) == instance AnExample(ref gFoo)
+    mapping gFoo via Inc;
+
+} *)
+
+(*
+
+\* BEGIN PLUSCAL TRANSLATION
+
+\* END PLUSCAL TRANSLATION
+
+*)
+
+\* BEGIN TRANSLATION
+====

--- a/test/files/pcalgen/MultiWithSemantics.tla.expectpcal
+++ b/test/files/pcalgen/MultiWithSemantics.tla.expectpcal
@@ -1,0 +1,65 @@
+---- MODULE MultiWithSemantics ----
+EXTENDS TLC, Integers, Sequences
+
+(* --mpcal MultiWithSemantics {
+
+mapping macro Inc {
+    read {
+        with(v = $variable) {
+            $variable := $variable + 1;
+            yield v;
+        };
+    }
+    write {
+        assert FALSE;
+    }
+}
+
+archetype AnExample(ref foo) {
+lbl:
+    with(x = foo, y = foo + x) {
+        print y;
+    };
+}
+
+variables gFoo = 0;
+
+fair process (Example = 1) == instance AnExample(ref gFoo)
+    mapping gFoo via Inc;
+
+} *)
+
+(*
+
+\* BEGIN PLUSCAL TRANSLATION
+--algorithm MultiWithSemantics {
+  variables gFoo = 0;
+  
+  fair process (Example = 1)
+  {
+    lbl:
+      with (
+        v1 = gFoo, 
+        gFoo0 = (gFoo) + (1), 
+        yielded_gFoo0 = v1, 
+        x = yielded_gFoo0, 
+        v0 = gFoo0
+      ) {
+        gFoo := (gFoo0) + (1);
+        with (
+          yielded_gFoo = v0, 
+          y = (yielded_gFoo) + (x)
+        ) {
+          print y;
+          goto Done;
+        };
+      };
+  }
+}
+
+\* END PLUSCAL TRANSLATION
+
+*)
+
+\* BEGIN TRANSLATION
+====

--- a/test/files/pcalgen/ResourceAccessBoundByWith.tla.expectpcal
+++ b/test/files/pcalgen/ResourceAccessBoundByWith.tla.expectpcal
@@ -44,13 +44,13 @@ process (Foo = 1) == instance AFoo(ref x)
   {
     lbl:
       either {
-        with (foo00 = (x) + (1)) {
-          with (yielded_x0 = foo00) {
-            with (y1 = yielded_x0) {
-              print y1;
-              goto lbl;
-            };
-          };
+        with (
+          foo00 = (x) + (1), 
+          yielded_x0 = foo00, 
+          y1 = yielded_x0
+        ) {
+          print y1;
+          goto lbl;
         };
       } or {
         skip;

--- a/test/files/pcalgen/bug_195.tla.expectpcal
+++ b/test/files/pcalgen/bug_195.tla.expectpcal
@@ -129,23 +129,24 @@ CONSTANT NUM_NODES
   fair process (UpdateCRDT = 0)
   {
     l1:
-      if(TRUE) {
-        with (i1 \in NODE_SET, i2 \in {x \in NODE_SET : ((crdt)[x]) # ((crdt)[i1])}) {
+      if (TRUE) {
+        with (
+          i1 \in NODE_SET, 
+          i2 \in {x \in NODE_SET : ((crdt)[x]) # ((crdt)[i1])}
+        ) {
           assert ((crdt)[i1]) # ((crdt)[i2]);
-          with (addk0 = MergeKeys(((crdt)[i1]).addMap, ((crdt)[i2]).addMap), remk0 = MergeKeys(((crdt)[i1]).remMap, ((crdt)[i2]).remMap)) {
-            with (add0 = [i \in DOMAIN (addk0) |-> IF CompareVectorClock((addk0)[i], (remk0)[i]) THEN NULL ELSE (addk0)[i]]) {
-              with (crdt0 = [crdt EXCEPT ![i1]["addMap"] = add0]) {
-                with (crdt1 = [crdt0 EXCEPT ![i2]["addMap"] = add0]) {
-                  with (rem0 = [i \in DOMAIN (remk0) |-> IF CompareVectorClock((addk0)[i], (remk0)[i]) THEN (remk0)[i] ELSE NULL]) {
-                    with (crdt2 = [crdt1 EXCEPT ![i1]["remMap"] = rem0]) {
-                      crdt := [crdt2 EXCEPT ![i2]["remMap"] = rem0];
-                      assert ((crdt)[i1]) = ((crdt)[i2]);
-                      goto l1;
-                    };
-                  };
-                };
-              };
-            };
+          with (
+            addk0 = MergeKeys(((crdt)[i1]).addMap, ((crdt)[i2]).addMap), 
+            remk0 = MergeKeys(((crdt)[i1]).remMap, ((crdt)[i2]).remMap), 
+            add0 = [i \in DOMAIN (addk0) |-> IF CompareVectorClock((addk0)[i], (remk0)[i]) THEN NULL ELSE (addk0)[i]], 
+            crdt0 = [crdt EXCEPT ![i1]["addMap"] = add0], 
+            crdt1 = [crdt0 EXCEPT ![i2]["addMap"] = add0], 
+            rem0 = [i \in DOMAIN (remk0) |-> IF CompareVectorClock((addk0)[i], (remk0)[i]) THEN (remk0)[i] ELSE NULL], 
+            crdt2 = [crdt1 EXCEPT ![i1]["remMap"] = rem0]
+          ) {
+            crdt := [crdt2 EXCEPT ![i2]["remMap"] = rem0];
+            assert ((crdt)[i1]) = ((crdt)[i2]);
+            goto l1;
           };
         };
       } else {
@@ -157,14 +158,14 @@ CONSTANT NUM_NODES
   {
     addItem:
       with (value1 = [cmd |-> AddCmd, elem |-> ELEM1]) {
-        if(((value1).cmd) = (AddCmd)) {
-          if(((((crdt)[self]).addMap)[(value1).elem]) # (NULL)) {
+        if (((value1).cmd) = (AddCmd)) {
+          if (((((crdt)[self]).addMap)[(value1).elem]) # (NULL)) {
             with (crdt3 = [crdt EXCEPT ![self]["addMap"][(value1).elem][self] = (((((crdt)[self]).addMap)[(value1).elem])[self]) + (1)]) {
               crdt := [crdt3 EXCEPT ![self]["remMap"][(value1).elem] = NULL];
               goto removeItem;
             };
           } else {
-            if(((((crdt)[self]).remMap)[(value1).elem]) # (NULL)) {
+            if (((((crdt)[self]).remMap)[(value1).elem]) # (NULL)) {
               with (crdt4 = [crdt EXCEPT ![self]["addMap"][(value1).elem][self] = 1]) {
                 crdt := [crdt4 EXCEPT ![self]["remMap"][(value1).elem] = NULL];
                 goto removeItem;
@@ -175,14 +176,14 @@ CONSTANT NUM_NODES
             };
           };
         } else {
-          if(((value1).cmd) = (RemoveCmd)) {
-            if(((((crdt)[self]).remMap)[(value1).elem]) # (NULL)) {
+          if (((value1).cmd) = (RemoveCmd)) {
+            if (((((crdt)[self]).remMap)[(value1).elem]) # (NULL)) {
               with (crdt5 = [crdt EXCEPT ![self]["addMap"][(value1).elem] = NULL]) {
                 crdt := [crdt5 EXCEPT ![self]["remMap"][(value1).elem][self] = (((((crdt5)[self]).remMap)[(value1).elem])[self]) + (1)];
                 goto removeItem;
               };
             } else {
-              if(((((crdt)[self]).addMap)[(value1).elem]) # (NULL)) {
+              if (((((crdt)[self]).addMap)[(value1).elem]) # (NULL)) {
                 with (crdt6 = [crdt EXCEPT ![self]["addMap"][(value1).elem] = NULL]) {
                   crdt := [crdt6 EXCEPT ![self]["remMap"][(value1).elem][self] = 1];
                   goto removeItem;
@@ -199,14 +200,14 @@ CONSTANT NUM_NODES
       };
     removeItem:
       with (value00 = [cmd |-> RemoveCmd, elem |-> ELEM1]) {
-        if(((value00).cmd) = (AddCmd)) {
-          if(((((crdt)[self]).addMap)[(value00).elem]) # (NULL)) {
+        if (((value00).cmd) = (AddCmd)) {
+          if (((((crdt)[self]).addMap)[(value00).elem]) # (NULL)) {
             with (crdt7 = [crdt EXCEPT ![self]["addMap"][(value00).elem][self] = (((((crdt)[self]).addMap)[(value00).elem])[self]) + (1)]) {
               crdt := [crdt7 EXCEPT ![self]["remMap"][(value00).elem] = NULL];
               goto Done;
             };
           } else {
-            if(((((crdt)[self]).remMap)[(value00).elem]) # (NULL)) {
+            if (((((crdt)[self]).remMap)[(value00).elem]) # (NULL)) {
               with (crdt8 = [crdt EXCEPT ![self]["addMap"][(value00).elem][self] = 1]) {
                 crdt := [crdt8 EXCEPT ![self]["remMap"][(value00).elem] = NULL];
                 goto Done;
@@ -217,14 +218,14 @@ CONSTANT NUM_NODES
             };
           };
         } else {
-          if(((value00).cmd) = (RemoveCmd)) {
-            if(((((crdt)[self]).remMap)[(value00).elem]) # (NULL)) {
+          if (((value00).cmd) = (RemoveCmd)) {
+            if (((((crdt)[self]).remMap)[(value00).elem]) # (NULL)) {
               with (crdt9 = [crdt EXCEPT ![self]["addMap"][(value00).elem] = NULL]) {
                 crdt := [crdt9 EXCEPT ![self]["remMap"][(value00).elem][self] = (((((crdt9)[self]).remMap)[(value00).elem])[self]) + (1)];
                 goto Done;
               };
             } else {
-              if(((((crdt)[self]).addMap)[(value00).elem]) # (NULL)) {
+              if (((((crdt)[self]).addMap)[(value00).elem]) # (NULL)) {
                 with (crdt10 = [crdt EXCEPT ![self]["addMap"][(value00).elem] = NULL]) {
                   crdt := [crdt10 EXCEPT ![self]["remMap"][(value00).elem][self] = 1];
                   goto Done;

--- a/test/files/pcalgen/bug_195_simple.tla.expectpcal
+++ b/test/files/pcalgen/bug_195_simple.tla.expectpcal
@@ -34,29 +34,32 @@ lbl:
   {
     lbl:
       with (v0 = [v EXCEPT ![0] = 1]) {
-        if(TRUE) {
-          with (v1 = [v0 EXCEPT ![1] = 2]) {
-            with (v2 = [v1 EXCEPT ![2] = 3]) {
-              if(TRUE) {
-                with (v3 = [v2 EXCEPT ![3] = 4]) {
-                  with (v4 = [v3 EXCEPT ![4] = 5]) {
-                    v := [v4 EXCEPT ![5] = 6];
-                    goto Done;
-                  };
-                };
-              } else {
-                v := v2;
+        if (TRUE) {
+          with (
+            v1 = [v0 EXCEPT ![1] = 2], 
+            v2 = [v1 EXCEPT ![2] = 3]
+          ) {
+            if (TRUE) {
+              with (
+                v3 = [v2 EXCEPT ![3] = 4], 
+                v4 = [v3 EXCEPT ![4] = 5]
+              ) {
+                v := [v4 EXCEPT ![5] = 6];
                 goto Done;
               };
+            } else {
+              v := v2;
+              goto Done;
             };
           };
         } else {
-          if(TRUE) {
-            with (v5 = [v0 EXCEPT ![3] = 4]) {
-              with (v6 = [v5 EXCEPT ![4] = 5]) {
-                v := [v6 EXCEPT ![5] = 6];
-                goto Done;
-              };
+          if (TRUE) {
+            with (
+              v5 = [v0 EXCEPT ![3] = 4], 
+              v6 = [v5 EXCEPT ![4] = 5]
+            ) {
+              v := [v6 EXCEPT ![5] = 6];
+              goto Done;
             };
           } else {
             v := v0;


### PR DESCRIPTION
There was a potential bug in how with statements were being transformed PCal-side.
The issue involves multiple resource reads (with indices, if you really want broken output) across multiple declarations in a single with statement.
PCal codegen would lift all the resource reads above the with statement, potentially leading to incorrect scoping if one binding referenced another.
This change forcibly splits up all with statements into single bindings, ensuring this problem can't happen.

This change, however, made the output PCal even uglier, and, inspired by @shayanh's formatting of the in-progress Raft spec, I decided to also add a with statement de-nesting pass to PCal generation, alongside a prettier multi-declaration printing mode for with statements declaring more than one thing. As a result, deeply nested with bindings can often show up as just lists of bindings, rather than `with <bind> <indent> ... with <bind> <indent> ... etc`, which get pretty painful to read after the first couple.

The overall result is illustrated in pcalgen/MultiWithSemantics.tla.expectpcal, with all the other expected output changes seeming (to my puny human eyes) either equivalent or strictly better, re: with handling.

Edit: oh, and I made a couple of whitespace details (space between `if` and `(`, and `while` and `(`) more consistent with how humans write code, since I was already changing pcalgen. No semantic changes, just a tiny space here and there.