### PR TITLE
Make TLA+ boolean operations short-circuit

### DIFF
--- a/distsys/tla/symbols.go
+++ b/distsys/tla/symbols.go
@@ -33,20 +33,10 @@ var TLA_TRUE = TLAValue{tlaValueBool(true)}
 var TLA_FALSE = TLAValue{tlaValueBool(false)}
 var TLA_BOOLEAN = MakeTLASet(TLA_TRUE, TLA_FALSE)
 
-func TLA_LogicalAndSymbol(lhs, rhs TLAValue) TLAValue {
-	return MakeTLABool(lhs.AsBool() && rhs.AsBool())
-}
-
-func TLA_LogicalOrSymbol(lhs, rhs TLAValue) TLAValue {
-	return MakeTLABool(lhs.AsBool() || rhs.AsBool())
-}
+// logical AND, OR, and IMPLIES symbols are special-cased in the compiler, because they are short-circuiting
 
 func TLA_LogicalNotSymbol(v TLAValue) TLAValue {
 	return MakeTLABool(!v.AsBool())
-}
-
-func TLA_ImpliesSymbol(lhs, rhs TLAValue) TLAValue {
-	return MakeTLABool(!lhs.AsBool() || rhs.AsBool())
 }
 
 func TLA_EquivSymbol(lhs, rhs TLAValue) TLAValue {

--- a/src/pgo/trans/MPCalGoCodegenPass.scala
+++ b/src/pgo/trans/MPCalGoCodegenPass.scala
@@ -549,13 +549,27 @@ object MPCalGoCodegenPass {
         d"tla.TLACrossProduct(${operands.view.map(translateExpr).separateBy(d", ")})"
       case call@TLAOperatorCall(_, prefix, arguments) =>
         assert(prefix.isEmpty)
-        ctx.bindings(ById(call.refersTo)) match {
-          case IndependentCallableBinding(bind) =>
-            d"$bind(${arguments.map(translateExpr).separateBy(d", ")})"
-          case DependentCallableBinding(bind) =>
-            d"$bind(${ctx.iface}, ${arguments.map(translateExpr).separateBy(d", ")})"
-          case ConstantBinding(bind) =>
-            d"$bind(${arguments.map(translateExpr).separateBy(d", ")})"
+        // special cases: boolean logic in TLC is short-circuiting, so we need to special case /\, \/, and => to avoid
+        // breaking situations that rely on it (bounds checks, etc, where part of the condition may crash)
+        call.refersTo match {
+          case ref if ref eq BuiltinModules.Intrinsics.memberSym(TLASymbol.LogicalAndSymbol) =>
+            val List(lhs, rhs) = arguments
+            d"tla.MakeTLABool(${translateExpr(lhs)}.AsBool() && ${translateExpr(rhs)}.AsBool())"
+          case ref if ref eq BuiltinModules.Intrinsics.memberSym(TLASymbol.LogicalOrSymbol) =>
+            val List(lhs, rhs) = arguments
+            d"tla.MakeTLABool(${translateExpr(lhs)}.AsBool() || ${translateExpr(rhs)}.AsBool())"
+          case ref if ref eq BuiltinModules.Intrinsics.memberSym(TLASymbol.ImpliesSymbol) =>
+            val List(lhs, rhs) = arguments
+            d"tla.MakeTLABool(!${translateExpr(lhs)}.AsBool() || ${translateExpr(rhs)}.AsBool())"
+          case _ =>
+            ctx.bindings(ById(call.refersTo)) match {
+              case IndependentCallableBinding(bind) =>
+                d"$bind(${arguments.map(translateExpr).separateBy(d", ")})"
+              case DependentCallableBinding(bind) =>
+                d"$bind(${ctx.iface}, ${arguments.map(translateExpr).separateBy(d", ")})"
+              case ConstantBinding(bind) =>
+                d"$bind(${arguments.map(translateExpr).separateBy(d", ")})"
+            }
         }
       case TLAIf(cond, tval, fval) =>
         d"func() $TLAValue {${

--- a/test/files/general/ExprTests.tla
+++ b/test/files/general/ExprTests.tla
@@ -34,6 +34,15 @@ Test9 == 82 % -39
 
 Test10 == 82 % 39
 
+\* three cases for short-circuiting boolean evaluation
+Test11 == /\ FALSE
+          /\ Assert(FALSE, "boom")
+
+Test12 == \/ TRUE
+          \/ Assert(FALSE, "boom")
+
+Test13 == FALSE => Assert(FALSE, "boom")
+
 (* --mpcal ExprTests {
 
     archetype ANothing() {

--- a/test/files/general/ExprTests.tla.expectpcal
+++ b/test/files/general/ExprTests.tla.expectpcal
@@ -34,6 +34,15 @@ Test9 == 82 % -39
 
 Test10 == 82 % 39
 
+\* three cases for short-circuiting boolean evaluation
+Test11 == /\ FALSE
+          /\ Assert(FALSE, "boom")
+
+Test12 == \/ TRUE
+          \/ Assert(FALSE, "boom")
+
+Test13 == FALSE => Assert(FALSE, "boom")
+
 (* --mpcal ExprTests {
 
     archetype ANothing() {

--- a/test/files/general/ExprTests.tla.gotests/ExprTests.go
+++ b/test/files/general/ExprTests.tla.gotests/ExprTests.go
@@ -2309,6 +2309,15 @@ func Test9(iface distsys.ArchetypeInterface) tla.TLAValue {
 func Test10(iface distsys.ArchetypeInterface) tla.TLAValue {
 	return tla.TLA_PercentSymbol(tla.MakeTLANumber(82), tla.MakeTLANumber(39))
 }
+func Test11(iface distsys.ArchetypeInterface) tla.TLAValue {
+	return tla.MakeTLABool(tla.TLA_FALSE.AsBool() && tla.TLA_Assert(tla.TLA_FALSE, tla.MakeTLAString("boom")).AsBool())
+}
+func Test12(iface distsys.ArchetypeInterface) tla.TLAValue {
+	return tla.MakeTLABool(tla.TLA_TRUE.AsBool() || tla.TLA_Assert(tla.TLA_FALSE, tla.MakeTLAString("boom")).AsBool())
+}
+func Test13(iface distsys.ArchetypeInterface) tla.TLAValue {
+	return tla.MakeTLABool(!tla.TLA_FALSE.AsBool() || tla.TLA_Assert(tla.TLA_FALSE, tla.MakeTLAString("boom")).AsBool())
+}
 
 var procTable = distsys.MakeMPCalProcTable()
 

--- a/test/files/general/ExprTests.tla.gotests/ExprTests_test.go
+++ b/test/files/general/ExprTests.tla.gotests/ExprTests_test.go
@@ -138,3 +138,27 @@ func TestTest10(t *testing.T) {
 		t.Fatalf("%v was not 4", result)
 	}
 }
+
+func TestTest11(t *testing.T) {
+	ctx := distsys.NewMPCalContextWithoutArchetype()
+	result := Test11(ctx.IFace())
+	if !result.Equal(tla.TLA_FALSE) {
+		t.Fatalf("%v was not FALSE", result)
+	}
+}
+
+func TestTest12(t *testing.T) {
+	ctx := distsys.NewMPCalContextWithoutArchetype()
+	result := Test12(ctx.IFace())
+	if !result.Equal(tla.TLA_TRUE) {
+		t.Fatalf("%v was not TRUE", result)
+	}
+}
+
+func TestTest13(t *testing.T) {
+	ctx := distsys.NewMPCalContextWithoutArchetype()
+	result := Test13(ctx.IFace())
+	if !result.Equal(tla.TLA_TRUE) {
+		t.Fatalf("%v was not TRUE", result)
+	}
+}

--- a/test/files/general/PBFail4_bug125.tla.gotests/PBFail4_bug125.go
+++ b/test/files/general/PBFail4_bug125.tla.gotests/PBFail4_bug125.go
@@ -398,7 +398,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition8, tla.TLA_TRUE), tla.TLA_NotEqualsSymbol(condition9, iface.Self())).AsBool() {
+			if tla.MakeTLABool(tla.TLA_EqualsSymbol(condition8, tla.TLA_TRUE).AsBool() && tla.TLA_NotEqualsSymbol(condition9, iface.Self()).AsBool()).AsBool() {
 				var exprRead12 tla.TLAValue
 				exprRead12, err = iface.Read(idx1, []tla.TLAValue{})
 				if err != nil {
@@ -518,7 +518,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition12, tla.TLA_TRUE), tla.TLA_NotEqualsSymbol(condition13, iface.Self())).AsBool() {
+			if tla.MakeTLABool(tla.TLA_EqualsSymbol(condition12, tla.TLA_TRUE).AsBool() && tla.TLA_NotEqualsSymbol(condition13, iface.Self()).AsBool()).AsBool() {
 				var exprRead17 tla.TLAValue
 				exprRead17, err = iface.Read(net3, []tla.TLAValue{tla.MakeTLATuple(iface.Self(), PUT_RESP(iface))})
 				if err != nil {

--- a/test/files/general/pbkvs.tla.gotests/pbkvs.go
+++ b/test/files/general/pbkvs.tla.gotests/pbkvs.go
@@ -154,7 +154,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition, iface.Self()), condition0).AsBool() {
+			if tla.MakeTLABool(tla.TLA_EqualsSymbol(condition, iface.Self()).AsBool() && condition0.AsBool()).AsBool() {
 				err = iface.Write(shouldSync, []tla.TLAValue{}, tla.TLA_TRUE)
 				if err != nil {
 					return err
@@ -379,7 +379,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					if err != nil {
 						return err
 					}
-					if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition6.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(3)), tla.TLA_EqualsSymbol(condition7.ApplyFunction(tla.MakeTLAString("to")), iface.Self())), tla.TLA_EqualsSymbol(condition8.ApplyFunction(tla.MakeTLAString("srcTyp")), BACKUP_SRC(iface))), tla.TLA_EqualsSymbol(condition9.ApplyFunction(tla.MakeTLAString("typ")), SYNC_RESP(iface))), tla.TLA_LogicalOrSymbol(tla.TLA_InSymbol(condition10.ApplyFunction(tla.MakeTLAString("from")), condition11), condition13)).AsBool() {
+					if !tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.TLA_EqualsSymbol(condition6.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(3)).AsBool() && tla.TLA_EqualsSymbol(condition7.ApplyFunction(tla.MakeTLAString("to")), iface.Self()).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition8.ApplyFunction(tla.MakeTLAString("srcTyp")), BACKUP_SRC(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition9.ApplyFunction(tla.MakeTLAString("typ")), SYNC_RESP(iface)).AsBool()).AsBool() && tla.MakeTLABool(tla.TLA_InSymbol(condition10.ApplyFunction(tla.MakeTLAString("from")), condition11).AsBool() || condition13.AsBool()).AsBool()).AsBool() {
 						return fmt.Errorf("%w: ((((((repResp).id) = (3)) /\\ (((repResp).to) = (self))) /\\ (((repResp).srcTyp) = (BACKUP_SRC))) /\\ (((repResp).typ) = (SYNC_RESP))) /\\ ((((repResp).from) \\in (replicaSet)) \\/ ((fd)[(repResp).from]))", distsys.ErrAssertionFailed)
 					}
 					var condition14 tla.TLAValue
@@ -472,7 +472,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					if err != nil {
 						return err
 					}
-					if !tla.TLA_LogicalAndSymbol(condition17, tla.TLA_EqualsSymbol(condition18, tla.MakeTLANumber(0))).AsBool() {
+					if !tla.MakeTLABool(condition17.AsBool() && tla.TLA_EqualsSymbol(condition18, tla.MakeTLANumber(0)).AsBool()).AsBool() {
 						return distsys.ErrCriticalSectionAborted
 					}
 					var exprRead9 tla.TLAValue
@@ -525,7 +525,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition19, iface.Self()), condition20).AsBool() {
+			if tla.MakeTLABool(tla.TLA_EqualsSymbol(condition19, iface.Self()).AsBool() && condition20.AsBool()).AsBool() {
 				return iface.Goto("AReplica.syncPrimary")
 			} else {
 				var exprRead11 tla.TLAValue
@@ -555,7 +555,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition22, iface.Self()), tla.TLA_EqualsSymbol(condition23.ApplyFunction(tla.MakeTLAString("srcTyp")), CLIENT_SRC(iface))).AsBool() {
+				if tla.MakeTLABool(tla.TLA_EqualsSymbol(condition22, iface.Self()).AsBool() && tla.TLA_EqualsSymbol(condition23.ApplyFunction(tla.MakeTLAString("srcTyp")), CLIENT_SRC(iface)).AsBool()).AsBool() {
 					return iface.Goto("AReplica.handlePrimary")
 				} else {
 					return iface.Goto("AReplica.handleBackup")
@@ -1165,7 +1165,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					if err != nil {
 						return err
 					}
-					if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalOrSymbol(tla.TLA_InSymbol(condition42.ApplyFunction(tla.MakeTLAString("from")), condition43), condition45), tla.TLA_EqualsSymbol(condition46.ApplyFunction(tla.MakeTLAString("to")), iface.Self())), tla.TLA_EqualsSymbol(condition47.ApplyFunction(tla.MakeTLAString("body")), ACK_MSG_BODY(iface))), tla.TLA_EqualsSymbol(condition48.ApplyFunction(tla.MakeTLAString("srcTyp")), BACKUP_SRC(iface))), tla.TLA_EqualsSymbol(condition49.ApplyFunction(tla.MakeTLAString("typ")), PUT_RESP(iface))), tla.TLA_EqualsSymbol(condition50.ApplyFunction(tla.MakeTLAString("id")), condition51.ApplyFunction(tla.MakeTLAString("id")))).AsBool() {
+					if !tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.TLA_InSymbol(condition42.ApplyFunction(tla.MakeTLAString("from")), condition43).AsBool() || condition45.AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition46.ApplyFunction(tla.MakeTLAString("to")), iface.Self()).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition47.ApplyFunction(tla.MakeTLAString("body")), ACK_MSG_BODY(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition48.ApplyFunction(tla.MakeTLAString("srcTyp")), BACKUP_SRC(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition49.ApplyFunction(tla.MakeTLAString("typ")), PUT_RESP(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition50.ApplyFunction(tla.MakeTLAString("id")), condition51.ApplyFunction(tla.MakeTLAString("id"))).AsBool()).AsBool() {
 						return fmt.Errorf("%w: ((((((((repResp).from) \\in (replicaSet)) \\/ ((fd)[(repResp).from])) /\\ (((repResp).to) = (self))) /\\ (((repResp).body) = (ACK_MSG_BODY))) /\\ (((repResp).srcTyp) = (BACKUP_SRC))) /\\ (((repResp).typ) = (PUT_RESP))) /\\ (((repResp).id) = ((req).id))", distsys.ErrAssertionFailed)
 					}
 					var exprRead36 tla.TLAValue
@@ -1212,7 +1212,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					if err != nil {
 						return err
 					}
-					if !tla.TLA_LogicalAndSymbol(condition53, tla.TLA_EqualsSymbol(condition54, tla.MakeTLANumber(0))).AsBool() {
+					if !tla.MakeTLABool(condition53.AsBool() && tla.TLA_EqualsSymbol(condition54, tla.MakeTLANumber(0)).AsBool()).AsBool() {
 						return distsys.ErrCriticalSectionAborted
 					}
 					var exprRead39 tla.TLAValue
@@ -1547,7 +1547,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition58.ApplyFunction(tla.MakeTLAString("to")), iface.Self()), tla.TLA_EqualsSymbol(condition59.ApplyFunction(tla.MakeTLAString("from")), condition60)), tla.TLA_EqualsSymbol(condition61.ApplyFunction(tla.MakeTLAString("body")), ACK_MSG_BODY(iface))), tla.TLA_EqualsSymbol(condition62.ApplyFunction(tla.MakeTLAString("srcTyp")), PRIMARY_SRC(iface))), tla.TLA_EqualsSymbol(condition63.ApplyFunction(tla.MakeTLAString("typ")), PUT_RESP(iface))), tla.TLA_EqualsSymbol(condition64.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(1))).AsBool() {
+				if !tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.TLA_EqualsSymbol(condition58.ApplyFunction(tla.MakeTLAString("to")), iface.Self()).AsBool() && tla.TLA_EqualsSymbol(condition59.ApplyFunction(tla.MakeTLAString("from")), condition60).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition61.ApplyFunction(tla.MakeTLAString("body")), ACK_MSG_BODY(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition62.ApplyFunction(tla.MakeTLAString("srcTyp")), PRIMARY_SRC(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition63.ApplyFunction(tla.MakeTLAString("typ")), PUT_RESP(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition64.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(1)).AsBool()).AsBool() {
 					return fmt.Errorf("%w: (((((((resp).to) = (self)) /\\ (((resp).from) = (replica))) /\\ (((resp).body) = (ACK_MSG_BODY))) /\\ (((resp).srcTyp) = (PRIMARY_SRC))) /\\ (((resp).typ) = (PUT_RESP))) /\\ (((resp).id) = (1))", distsys.ErrAssertionFailed)
 				}
 				var exprRead52 tla.TLAValue
@@ -1576,7 +1576,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if !tla.TLA_LogicalAndSymbol(condition66, tla.TLA_EqualsSymbol(condition67, tla.MakeTLANumber(0))).AsBool() {
+				if !tla.MakeTLABool(condition66.AsBool() && tla.TLA_EqualsSymbol(condition67, tla.MakeTLANumber(0)).AsBool()).AsBool() {
 					return distsys.ErrCriticalSectionAborted
 				}
 				return iface.Goto("APutClient.sndPutReq")
@@ -1781,7 +1781,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition71.ApplyFunction(tla.MakeTLAString("to")), iface.Self()), tla.TLA_EqualsSymbol(condition72.ApplyFunction(tla.MakeTLAString("from")), condition73)), tla.TLA_EqualsSymbol(condition74.ApplyFunction(tla.MakeTLAString("srcTyp")), PRIMARY_SRC(iface))), tla.TLA_EqualsSymbol(condition75.ApplyFunction(tla.MakeTLAString("typ")), GET_RESP(iface))), tla.TLA_EqualsSymbol(condition76.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(2))).AsBool() {
+				if !tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.TLA_EqualsSymbol(condition71.ApplyFunction(tla.MakeTLAString("to")), iface.Self()).AsBool() && tla.TLA_EqualsSymbol(condition72.ApplyFunction(tla.MakeTLAString("from")), condition73).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition74.ApplyFunction(tla.MakeTLAString("srcTyp")), PRIMARY_SRC(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition75.ApplyFunction(tla.MakeTLAString("typ")), GET_RESP(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition76.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(2)).AsBool()).AsBool() {
 					return fmt.Errorf("%w: ((((((resp).to) = (self)) /\\ (((resp).from) = (replica))) /\\ (((resp).srcTyp) = (PRIMARY_SRC))) /\\ (((resp).typ) = (GET_RESP))) /\\ (((resp).id) = (2))", distsys.ErrAssertionFailed)
 				}
 				var exprRead59 tla.TLAValue
@@ -1810,7 +1810,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if !tla.TLA_LogicalAndSymbol(condition78, tla.TLA_EqualsSymbol(condition79, tla.MakeTLANumber(0))).AsBool() {
+				if !tla.MakeTLABool(condition78.AsBool() && tla.TLA_EqualsSymbol(condition79, tla.MakeTLANumber(0)).AsBool()).AsBool() {
 					return distsys.ErrCriticalSectionAborted
 				}
 				return iface.Goto("AGetClient.sndGetReq")

--- a/test/files/general/proxy.tla.gotests/proxy.go
+++ b/test/files/general/proxy.tla.gotests/proxy.go
@@ -82,7 +82,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if !tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition.ApplyFunction(tla.MakeTLAString("to")), ProxyID(iface)), tla.TLA_EqualsSymbol(condition0.ApplyFunction(tla.MakeTLAString("typ")), REQ_MSG_TYP(iface))).AsBool() {
+				if !tla.MakeTLABool(tla.TLA_EqualsSymbol(condition.ApplyFunction(tla.MakeTLAString("to")), ProxyID(iface)).AsBool() && tla.TLA_EqualsSymbol(condition0.ApplyFunction(tla.MakeTLAString("typ")), REQ_MSG_TYP(iface)).AsBool()).AsBool() {
 					return fmt.Errorf("%w: (((msg).to) = (ProxyID)) /\\ (((msg).typ) = (REQ_MSG_TYP))", distsys.ErrAssertionFailed)
 				}
 				var exprRead0 tla.TLAValue
@@ -249,7 +249,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if tla.TLA_LogicalOrSymbol(tla.TLA_NotEqualsSymbol(tmp.ApplyFunction(tla.MakeTLAString("from")), condition4), tla.TLA_NotEqualsSymbol(tmp.ApplyFunction(tla.MakeTLAString("id")), condition5.ApplyFunction(tla.MakeTLAString("id")))).AsBool() {
+				if tla.MakeTLABool(tla.TLA_NotEqualsSymbol(tmp.ApplyFunction(tla.MakeTLAString("from")), condition4).AsBool() || tla.TLA_NotEqualsSymbol(tmp.ApplyFunction(tla.MakeTLAString("id")), condition5.ApplyFunction(tla.MakeTLAString("id"))).AsBool()).AsBool() {
 					return iface.Goto("AProxy.proxyRcvMsg")
 				} else {
 					err = iface.Write(proxyResp0, []tla.TLAValue{}, tmp)
@@ -286,7 +286,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					if err != nil {
 						return err
 					}
-					if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition6.ApplyFunction(tla.MakeTLAString("to")), ProxyID(iface)), tla.TLA_EqualsSymbol(condition7.ApplyFunction(tla.MakeTLAString("from")), condition8)), tla.TLA_EqualsSymbol(condition9.ApplyFunction(tla.MakeTLAString("id")), condition10.ApplyFunction(tla.MakeTLAString("id")))), tla.TLA_EqualsSymbol(condition11.ApplyFunction(tla.MakeTLAString("typ")), PROXY_RESP_MSG_TYP(iface))).AsBool() {
+					if !tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.TLA_EqualsSymbol(condition6.ApplyFunction(tla.MakeTLAString("to")), ProxyID(iface)).AsBool() && tla.TLA_EqualsSymbol(condition7.ApplyFunction(tla.MakeTLAString("from")), condition8).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition9.ApplyFunction(tla.MakeTLAString("id")), condition10.ApplyFunction(tla.MakeTLAString("id"))).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition11.ApplyFunction(tla.MakeTLAString("typ")), PROXY_RESP_MSG_TYP(iface)).AsBool()).AsBool() {
 						return fmt.Errorf("%w: (((((proxyResp).to) = (ProxyID)) /\\ (((proxyResp).from) = (idx))) /\\ (((proxyResp).id) = ((msg).id))) /\\ (((proxyResp).typ) = (PROXY_RESP_MSG_TYP))", distsys.ErrAssertionFailed)
 					}
 					return iface.Goto("AProxy.sendMsgToClient")
@@ -461,7 +461,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition14.ApplyFunction(tla.MakeTLAString("to")), iface.Self()), tla.TLA_EqualsSymbol(condition15.ApplyFunction(tla.MakeTLAString("from")), ProxyID(iface))), tla.TLA_EqualsSymbol(condition16.ApplyFunction(tla.MakeTLAString("typ")), PROXY_REQ_MSG_TYP(iface))).AsBool() {
+			if !tla.MakeTLABool(tla.MakeTLABool(tla.TLA_EqualsSymbol(condition14.ApplyFunction(tla.MakeTLAString("to")), iface.Self()).AsBool() && tla.TLA_EqualsSymbol(condition15.ApplyFunction(tla.MakeTLAString("from")), ProxyID(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition16.ApplyFunction(tla.MakeTLAString("typ")), PROXY_REQ_MSG_TYP(iface)).AsBool()).AsBool() {
 				return fmt.Errorf("%w: ((((msg).to) = (self)) /\\ (((msg).from) = (ProxyID))) /\\ (((msg).typ) = (PROXY_REQ_MSG_TYP))", distsys.ErrAssertionFailed)
 			}
 			if iface.GetConstant("EXPLORE_FAIL")().AsBool() {
@@ -693,7 +693,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition17.ApplyFunction(tla.MakeTLAString("to")), iface.Self()), tla.TLA_EqualsSymbol(condition18.ApplyFunction(tla.MakeTLAString("id")), condition19)), tla.TLA_EqualsSymbol(condition20.ApplyFunction(tla.MakeTLAString("from")), ProxyID(iface))), tla.TLA_EqualsSymbol(condition21.ApplyFunction(tla.MakeTLAString("typ")), RESP_MSG_TYP(iface))).AsBool() {
+			if !tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.TLA_EqualsSymbol(condition17.ApplyFunction(tla.MakeTLAString("to")), iface.Self()).AsBool() && tla.TLA_EqualsSymbol(condition18.ApplyFunction(tla.MakeTLAString("id")), condition19).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition20.ApplyFunction(tla.MakeTLAString("from")), ProxyID(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition21.ApplyFunction(tla.MakeTLAString("typ")), RESP_MSG_TYP(iface)).AsBool()).AsBool() {
 				return fmt.Errorf("%w: (((((resp).to) = (self)) /\\ (((resp).id) = (reqId))) /\\ (((resp).from) = (ProxyID))) /\\ (((resp).typ) = (RESP_MSG_TYP))", distsys.ErrAssertionFailed)
 			}
 			var exprRead20 tla.TLAValue

--- a/test/files/general/replicated_kv.tla.gotests/replicated_kv.go
+++ b/test/files/general/replicated_kv.tla.gotests/replicated_kv.go
@@ -411,7 +411,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if tla.TLA_LogicalOrSymbol(tla.TLA_EqualsSymbol(condition8, tla.MakeTLANumber(0)), tla.TLA_LessThanSymbol(condition9.ApplyFunction(client), condition10)).AsBool() {
+				if tla.MakeTLABool(tla.TLA_EqualsSymbol(condition8, tla.MakeTLANumber(0)).AsBool() || tla.TLA_LessThanSymbol(condition9.ApplyFunction(client), condition10).AsBool()).AsBool() {
 					var exprRead14 tla.TLAValue
 					exprRead14, err = iface.Read(currentClocks2, []tla.TLAValue{})
 					if err != nil {
@@ -510,7 +510,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if !tla.TLA_LogicalOrSymbol(tla.TLA_EqualsSymbol(condition13.ApplyFunction(tla.MakeTLAString("op")), iface.GetConstant("GET_MSG")()), tla.TLA_EqualsSymbol(condition14.ApplyFunction(tla.MakeTLAString("op")), iface.GetConstant("PUT_MSG")())).AsBool() {
+				if !tla.MakeTLABool(tla.TLA_EqualsSymbol(condition13.ApplyFunction(tla.MakeTLAString("op")), iface.GetConstant("GET_MSG")()).AsBool() || tla.TLA_EqualsSymbol(condition14.ApplyFunction(tla.MakeTLAString("op")), iface.GetConstant("PUT_MSG")()).AsBool()).AsBool() {
 					return fmt.Errorf("%w: (((firstPending).op) = (GET_MSG)) \\/ (((firstPending).op) = (PUT_MSG))", distsys.ErrAssertionFailed)
 				}
 				var exprRead18 tla.TLAValue
@@ -558,7 +558,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					if err != nil {
 						return err
 					}
-					err = iface.Write(chooseMessage, []tla.TLAValue{}, tla.TLA_LogicalOrSymbol(tla.TLA_LessThanSymbol(exprRead19, exprRead20), tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(exprRead21, exprRead22), tla.TLA_LessThanSymbol(client0, exprRead23))))
+					err = iface.Write(chooseMessage, []tla.TLAValue{}, tla.MakeTLABool(tla.TLA_LessThanSymbol(exprRead19, exprRead20).AsBool() || tla.MakeTLABool(tla.TLA_EqualsSymbol(exprRead21, exprRead22).AsBool() && tla.TLA_LessThanSymbol(client0, exprRead23).AsBool()).AsBool()))
 					if err != nil {
 						return err
 					}
@@ -1274,7 +1274,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if tla.TLA_LogicalAndSymbol(tla.TLA_LessThanOrEqualSymbol(condition34, tla.TLA_MinusSymbol(iface.GetConstant("NUM_REPLICAS")(), tla.MakeTLANumber(1))), tla.TLA_NotEqualsSymbol(condition36, tla.TLA_NegationSymbol(tla.MakeTLANumber(1)))).AsBool() {
+			if tla.MakeTLABool(tla.TLA_LessThanOrEqualSymbol(condition34, tla.TLA_MinusSymbol(iface.GetConstant("NUM_REPLICAS")(), tla.MakeTLANumber(1))).AsBool() && tla.TLA_NotEqualsSymbol(condition36, tla.TLA_NegationSymbol(tla.MakeTLANumber(1))).AsBool()).AsBool() {
 				var exprRead59 tla.TLAValue
 				exprRead59, err = iface.Read(putReq0, []tla.TLAValue{})
 				if err != nil {
@@ -1488,7 +1488,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if tla.TLA_LogicalAndSymbol(tla.TLA_LessThanOrEqualSymbol(condition42, tla.TLA_MinusSymbol(iface.GetConstant("NUM_REPLICAS")(), tla.MakeTLANumber(1))), tla.TLA_NotEqualsSymbol(tla.MakeTLANumber(0), tla.TLA_NegationSymbol(tla.MakeTLANumber(1)))).AsBool() {
+			if tla.MakeTLABool(tla.TLA_LessThanOrEqualSymbol(condition42, tla.TLA_MinusSymbol(iface.GetConstant("NUM_REPLICAS")(), tla.MakeTLANumber(1))).AsBool() && tla.TLA_NotEqualsSymbol(tla.MakeTLANumber(0), tla.TLA_NegationSymbol(tla.MakeTLANumber(1))).AsBool()).AsBool() {
 				var exprRead64 tla.TLAValue
 				exprRead64, err = iface.Read(msg29, []tla.TLAValue{})
 				if err != nil {
@@ -1653,7 +1653,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if tla.TLA_LogicalAndSymbol(tla.TLA_LessThanOrEqualSymbol(condition46, tla.TLA_MinusSymbol(iface.GetConstant("NUM_REPLICAS")(), tla.MakeTLANumber(1))), tla.TLA_NotEqualsSymbol(condition48, tla.TLA_NegationSymbol(tla.MakeTLANumber(1)))).AsBool() {
+			if tla.MakeTLABool(tla.TLA_LessThanOrEqualSymbol(condition46, tla.TLA_MinusSymbol(iface.GetConstant("NUM_REPLICAS")(), tla.MakeTLANumber(1))).AsBool() && tla.TLA_NotEqualsSymbol(condition48, tla.TLA_NegationSymbol(tla.MakeTLANumber(1))).AsBool()).AsBool() {
 				var exprRead71 tla.TLAValue
 				exprRead71, err = iface.Read(msg31, []tla.TLAValue{})
 				if err != nil {

--- a/test/files/gogen/bug_167.tla.gotests/bug_167.go
+++ b/test/files/gogen/bug_167.tla.gotests/bug_167.go
@@ -154,7 +154,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition, iface.Self()), condition0).AsBool() {
+			if tla.MakeTLABool(tla.TLA_EqualsSymbol(condition, iface.Self()).AsBool() && condition0.AsBool()).AsBool() {
 				err = iface.Write(shouldSync, []tla.TLAValue{}, tla.TLA_TRUE)
 				if err != nil {
 					return err
@@ -379,7 +379,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					if err != nil {
 						return err
 					}
-					if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition6.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(3)), tla.TLA_EqualsSymbol(condition7.ApplyFunction(tla.MakeTLAString("to")), iface.Self())), tla.TLA_EqualsSymbol(condition8.ApplyFunction(tla.MakeTLAString("srcTyp")), BACKUP_SRC(iface))), tla.TLA_EqualsSymbol(condition9.ApplyFunction(tla.MakeTLAString("typ")), SYNC_RESP(iface))), tla.TLA_LogicalOrSymbol(tla.TLA_InSymbol(condition10.ApplyFunction(tla.MakeTLAString("from")), condition11), condition13)).AsBool() {
+					if !tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.TLA_EqualsSymbol(condition6.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(3)).AsBool() && tla.TLA_EqualsSymbol(condition7.ApplyFunction(tla.MakeTLAString("to")), iface.Self()).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition8.ApplyFunction(tla.MakeTLAString("srcTyp")), BACKUP_SRC(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition9.ApplyFunction(tla.MakeTLAString("typ")), SYNC_RESP(iface)).AsBool()).AsBool() && tla.MakeTLABool(tla.TLA_InSymbol(condition10.ApplyFunction(tla.MakeTLAString("from")), condition11).AsBool() || condition13.AsBool()).AsBool()).AsBool() {
 						return fmt.Errorf("%w: ((((((repResp).id) = (3)) /\\ (((repResp).to) = (self))) /\\ (((repResp).srcTyp) = (BACKUP_SRC))) /\\ (((repResp).typ) = (SYNC_RESP))) /\\ ((((repResp).from) \\in (replicaSet)) \\/ ((fd)[(repResp).from]))", distsys.ErrAssertionFailed)
 					}
 					var condition14 tla.TLAValue
@@ -472,7 +472,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					if err != nil {
 						return err
 					}
-					if !tla.TLA_LogicalAndSymbol(condition17, tla.TLA_EqualsSymbol(condition18, tla.MakeTLANumber(0))).AsBool() {
+					if !tla.MakeTLABool(condition17.AsBool() && tla.TLA_EqualsSymbol(condition18, tla.MakeTLANumber(0)).AsBool()).AsBool() {
 						return distsys.ErrCriticalSectionAborted
 					}
 					var exprRead9 tla.TLAValue
@@ -525,7 +525,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 			if err != nil {
 				return err
 			}
-			if tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition19, iface.Self()), condition20).AsBool() {
+			if tla.MakeTLABool(tla.TLA_EqualsSymbol(condition19, iface.Self()).AsBool() && condition20.AsBool()).AsBool() {
 				return iface.Goto("AReplica.syncPrimary")
 			} else {
 				var exprRead11 tla.TLAValue
@@ -555,7 +555,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition22, iface.Self()), tla.TLA_EqualsSymbol(condition23.ApplyFunction(tla.MakeTLAString("srcTyp")), CLIENT_SRC(iface))).AsBool() {
+				if tla.MakeTLABool(tla.TLA_EqualsSymbol(condition22, iface.Self()).AsBool() && tla.TLA_EqualsSymbol(condition23.ApplyFunction(tla.MakeTLAString("srcTyp")), CLIENT_SRC(iface)).AsBool()).AsBool() {
 					return iface.Goto("AReplica.handlePrimary")
 				} else {
 					return iface.Goto("AReplica.handleBackup")
@@ -1165,7 +1165,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					if err != nil {
 						return err
 					}
-					if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalOrSymbol(tla.TLA_InSymbol(condition42.ApplyFunction(tla.MakeTLAString("from")), condition43), condition45), tla.TLA_EqualsSymbol(condition46.ApplyFunction(tla.MakeTLAString("to")), iface.Self())), tla.TLA_EqualsSymbol(condition47.ApplyFunction(tla.MakeTLAString("body")), ACK_MSG_BODY(iface))), tla.TLA_EqualsSymbol(condition48.ApplyFunction(tla.MakeTLAString("srcTyp")), BACKUP_SRC(iface))), tla.TLA_EqualsSymbol(condition49.ApplyFunction(tla.MakeTLAString("typ")), PUT_RESP(iface))), tla.TLA_EqualsSymbol(condition50.ApplyFunction(tla.MakeTLAString("id")), condition51.ApplyFunction(tla.MakeTLAString("id")))).AsBool() {
+					if !tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.TLA_InSymbol(condition42.ApplyFunction(tla.MakeTLAString("from")), condition43).AsBool() || condition45.AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition46.ApplyFunction(tla.MakeTLAString("to")), iface.Self()).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition47.ApplyFunction(tla.MakeTLAString("body")), ACK_MSG_BODY(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition48.ApplyFunction(tla.MakeTLAString("srcTyp")), BACKUP_SRC(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition49.ApplyFunction(tla.MakeTLAString("typ")), PUT_RESP(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition50.ApplyFunction(tla.MakeTLAString("id")), condition51.ApplyFunction(tla.MakeTLAString("id"))).AsBool()).AsBool() {
 						return fmt.Errorf("%w: ((((((((repResp).from) \\in (replicaSet)) \\/ ((fd)[(repResp).from])) /\\ (((repResp).to) = (self))) /\\ (((repResp).body) = (ACK_MSG_BODY))) /\\ (((repResp).srcTyp) = (BACKUP_SRC))) /\\ (((repResp).typ) = (PUT_RESP))) /\\ (((repResp).id) = ((req).id))", distsys.ErrAssertionFailed)
 					}
 					var exprRead36 tla.TLAValue
@@ -1212,7 +1212,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 					if err != nil {
 						return err
 					}
-					if !tla.TLA_LogicalAndSymbol(condition53, tla.TLA_EqualsSymbol(condition54, tla.MakeTLANumber(0))).AsBool() {
+					if !tla.MakeTLABool(condition53.AsBool() && tla.TLA_EqualsSymbol(condition54, tla.MakeTLANumber(0)).AsBool()).AsBool() {
 						return distsys.ErrCriticalSectionAborted
 					}
 					var exprRead39 tla.TLAValue
@@ -1549,7 +1549,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition58.ApplyFunction(tla.MakeTLAString("to")), iface.Self()), tla.TLA_EqualsSymbol(condition59.ApplyFunction(tla.MakeTLAString("from")), condition60)), tla.TLA_EqualsSymbol(condition61.ApplyFunction(tla.MakeTLAString("body")), ACK_MSG_BODY(iface))), tla.TLA_EqualsSymbol(condition62.ApplyFunction(tla.MakeTLAString("srcTyp")), PRIMARY_SRC(iface))), tla.TLA_EqualsSymbol(condition63.ApplyFunction(tla.MakeTLAString("typ")), PUT_RESP(iface))), tla.TLA_EqualsSymbol(condition64.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(1))).AsBool() {
+				if !tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.TLA_EqualsSymbol(condition58.ApplyFunction(tla.MakeTLAString("to")), iface.Self()).AsBool() && tla.TLA_EqualsSymbol(condition59.ApplyFunction(tla.MakeTLAString("from")), condition60).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition61.ApplyFunction(tla.MakeTLAString("body")), ACK_MSG_BODY(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition62.ApplyFunction(tla.MakeTLAString("srcTyp")), PRIMARY_SRC(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition63.ApplyFunction(tla.MakeTLAString("typ")), PUT_RESP(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition64.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(1)).AsBool()).AsBool() {
 					return fmt.Errorf("%w: (((((((resp).to) = (self)) /\\ (((resp).from) = (replica))) /\\ (((resp).body) = (ACK_MSG_BODY))) /\\ (((resp).srcTyp) = (PRIMARY_SRC))) /\\ (((resp).typ) = (PUT_RESP))) /\\ (((resp).id) = (1))", distsys.ErrAssertionFailed)
 				}
 				return iface.Goto("APutClient.putClientLoop")
@@ -1569,7 +1569,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if !tla.TLA_LogicalAndSymbol(condition66, tla.TLA_EqualsSymbol(condition67, tla.MakeTLANumber(0))).AsBool() {
+				if !tla.MakeTLABool(condition66.AsBool() && tla.TLA_EqualsSymbol(condition67, tla.MakeTLANumber(0)).AsBool()).AsBool() {
 					return distsys.ErrCriticalSectionAborted
 				}
 				return iface.Goto("APutClient.sndPutReq")
@@ -1762,7 +1762,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if !tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_LogicalAndSymbol(tla.TLA_EqualsSymbol(condition71.ApplyFunction(tla.MakeTLAString("to")), iface.Self()), tla.TLA_EqualsSymbol(condition72.ApplyFunction(tla.MakeTLAString("from")), condition73)), tla.TLA_EqualsSymbol(condition74.ApplyFunction(tla.MakeTLAString("srcTyp")), PRIMARY_SRC(iface))), tla.TLA_EqualsSymbol(condition75.ApplyFunction(tla.MakeTLAString("typ")), GET_RESP(iface))), tla.TLA_EqualsSymbol(condition76.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(2))).AsBool() {
+				if !tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.MakeTLABool(tla.TLA_EqualsSymbol(condition71.ApplyFunction(tla.MakeTLAString("to")), iface.Self()).AsBool() && tla.TLA_EqualsSymbol(condition72.ApplyFunction(tla.MakeTLAString("from")), condition73).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition74.ApplyFunction(tla.MakeTLAString("srcTyp")), PRIMARY_SRC(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition75.ApplyFunction(tla.MakeTLAString("typ")), GET_RESP(iface)).AsBool()).AsBool() && tla.TLA_EqualsSymbol(condition76.ApplyFunction(tla.MakeTLAString("id")), tla.MakeTLANumber(2)).AsBool()).AsBool() {
 					return fmt.Errorf("%w: ((((((resp).to) = (self)) /\\ (((resp).from) = (replica))) /\\ (((resp).srcTyp) = (PRIMARY_SRC))) /\\ (((resp).typ) = (GET_RESP))) /\\ (((resp).id) = (2))", distsys.ErrAssertionFailed)
 				}
 				return iface.Goto("AGetClient.getClientLoop")
@@ -1782,7 +1782,7 @@ var jumpTable = distsys.MakeMPCalJumpTable(
 				if err != nil {
 					return err
 				}
-				if !tla.TLA_LogicalAndSymbol(condition78, tla.TLA_EqualsSymbol(condition79, tla.MakeTLANumber(0))).AsBool() {
+				if !tla.MakeTLABool(condition78.AsBool() && tla.TLA_EqualsSymbol(condition79, tla.MakeTLANumber(0)).AsBool()).AsBool() {
 					return distsys.ErrCriticalSectionAborted
 				}
 				return iface.Goto("AGetClient.sndGetReq")

--- a/test/pgo/util/TLAExprInterpreterTests.scala
+++ b/test/pgo/util/TLAExprInterpreterTests.scala
@@ -127,4 +127,18 @@ class TLAExprInterpreterTests extends AnyFunSuite {
   checkTypeError("modulo with negative") {
     raw"""82 % -39"""
   }
+
+  checkPass("short-circuiting AND") {
+    raw"""/\ FALSE
+         |/\ Assert(FALSE, "boom")""".stripMargin -> TLAValueBool(false)
+  }
+
+  checkPass("short-circuiting OR") {
+    raw"""\/ TRUE
+         |\/ Assert(FALSE, "boom")""".stripMargin -> TLAValueBool(true)
+  }
+
+  checkPass("short-circuiting logical implication") {
+    raw"""FALSE => Assert(FALSE, "boom")""" -> TLAValueBool(true)
+  }
 }


### PR DESCRIPTION
Does what the title says.

It turns out (thanks, @shayanh!) that up until this point I had not considered that TLA+ boolean ops are short-circuiting.
Now, theoretically, (mumble mumble TLA+ book), but in practice they are treated that way.

So, these changes make sure PGo supports this. It makes boolean ops "special", and handles them in a short-circuiting way, unlike all other ops, which have all of their arguments pre-evaluated before being allowed to execute.