### PR TITLE
Fix an issue with channels

### DIFF
--- a/distsys/resources/channels.go
+++ b/distsys/resources/channels.go
@@ -35,6 +35,7 @@ func InputChannelMaker(channel <-chan tla.TLAValue) distsys.ArchetypeResourceMak
 
 func (res *InputChannel) Abort() chan struct{} {
 	res.buffer = append(res.backlogBuffer, res.buffer...)
+	res.backlogBuffer = nil
 	return nil
 }
 


### PR DESCRIPTION
This fixes a bug where consecutive calls to `PreCommit()` and `Abort()` can put more items in `backlogBuffer` than really should be there.