### PR TITLE
CRDT changes for benchmark

### DIFF
--- a/test/files/general/aworset.tla.gotests/aworset_test.go
+++ b/test/files/general/aworset.tla.gotests/aworset_test.go
@@ -23,7 +23,7 @@ func getNodeMapCtx(self tla.TLAValue, nodeAddrMap map[tla.TLAValue]string, const
 			}
 			return resources.CRDTMaker(index, peers, func(index tla.TLAValue) string {
 				return nodeAddrMap[index]
-			}, 5, resources.MakeAWORSet)
+			}, 5, 3, resources.MakeAWORSet)
 		})))...)
 	return ctx
 }

--- a/test/files/general/aworset.tla.gotests/aworset_test.go
+++ b/test/files/general/aworset.tla.gotests/aworset_test.go
@@ -23,7 +23,7 @@ func getNodeMapCtx(self tla.TLAValue, nodeAddrMap map[tla.TLAValue]string, const
 			}
 			return resources.CRDTMaker(index, peers, func(index tla.TLAValue) string {
 				return nodeAddrMap[index]
-			}, resources.MakeAWORSet)
+			}, 5, resources.MakeAWORSet)
 		})))...)
 	return ctx
 }

--- a/test/files/general/gcounter.tla.gotests/gcounter_test.go
+++ b/test/files/general/gcounter.tla.gotests/gcounter_test.go
@@ -24,7 +24,7 @@ func getNodeMapCtx(self tla.TLAValue, nodeAddrMap map[tla.TLAValue]string, const
 			}
 			return resources.CRDTMaker(index, peers, func(index tla.TLAValue) string {
 				return nodeAddrMap[index]
-			}, 5, 3, resources.MakeGCounter)
+			}, 5, 9, resources.MakeGCounter)
 		})))...)
 	return ctx
 }
@@ -35,7 +35,7 @@ func TestGCounter(t *testing.T) {
 		distsys.DefineConstantValue("NUM_NODES", tla.MakeTLANumber(int32(numNodes))),
 	}
 
-	nodeAddrMap := make(map[tla.TLAValue]string, numNodes)
+	nodeAddrMap := make(map[tla.TLAValue]string, numNodes+1)
 	for i := 1; i <= numNodes; i++ {
 		portNum := 9000 + i
 		addr := fmt.Sprintf("localhost:%d", portNum)

--- a/test/files/general/gcounter.tla.gotests/gcounter_test.go
+++ b/test/files/general/gcounter.tla.gotests/gcounter_test.go
@@ -24,13 +24,13 @@ func getNodeMapCtx(self tla.TLAValue, nodeAddrMap map[tla.TLAValue]string, const
 			}
 			return resources.CRDTMaker(index, peers, func(index tla.TLAValue) string {
 				return nodeAddrMap[index]
-			}, 5, resources.MakeGCounter)
+			}, 5, 3, resources.MakeGCounter)
 		})))...)
 	return ctx
 }
 
 func TestGCounter(t *testing.T) {
-	numNodes := 3
+	numNodes := 10
 	constants := []distsys.MPCalContextConfigFn{
 		distsys.DefineConstantValue("NUM_NODES", tla.MakeTLANumber(int32(numNodes))),
 	}

--- a/test/files/general/gcounter.tla.gotests/gcounter_test.go
+++ b/test/files/general/gcounter.tla.gotests/gcounter_test.go
@@ -24,7 +24,7 @@ func getNodeMapCtx(self tla.TLAValue, nodeAddrMap map[tla.TLAValue]string, const
 			}
 			return resources.CRDTMaker(index, peers, func(index tla.TLAValue) string {
 				return nodeAddrMap[index]
-			}, resources.MakeGCounter)
+			}, 5, resources.MakeGCounter)
 		})))...)
 	return ctx
 }


### PR DESCRIPTION
CRDT changes after couple of benchmark tests
* make broadcastInterval configurable
* change merge queue into a single merge value (the queued values can be merged themselves into a single value)
* close the RPC listener on Close()
* In `Receive`, do a preflight check to see if incoming state will result to new state with faster RLocking on stateMu. If the incoming merge isn't needed, discard.

StateLogger
* Log to specified file, the current CRDT value after performing 1. Write 2. Merge
* Turned on/off with `logStateEnabled` flag (maybe make sense to make it an env var instead...)

Selective broadcast
* Based on configurable `broadcastSize`, the `broadcast()` process will randomly select specified number of peers to try connecting and broadcast states only to these peers.